### PR TITLE
Unbreak performance test

### DIFF
--- a/client/services/code_preprocessors/PythonCodePreprocessorService.js
+++ b/client/services/code_preprocessors/PythonCodePreprocessorService.js
@@ -168,7 +168,6 @@ tie.factory('PythonCodePreprocessorService', [
             '(get_test_input(test_input, input_size))'),
           '        finish = time.time() - start',
           '        time_array.append(finish)',
-          '    return time_array',
           '    if time_array[1] > ' + UPPER_BOUND_RATIO_IF_LINEAR + (
             ' * time_array[0]:'),
           '        return "not linear"',

--- a/client/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
+++ b/client/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
@@ -261,7 +261,6 @@ describe('PythonCodePreprocessorService', function() {
           '        output = StudentCode().katamariDamashi(get_test_input(test_input, input_size))',
           '        finish = time.time() - start',
           '        time_array.append(finish)',
-          '    return time_array',
           '    if time_array[1] > 30 * time_array[0]:',
           '        return "not linear"',
           '    return "linear"',


### PR DESCRIPTION
So this isn't a fix and doesn't include linear regression, but I figured while I read up on that I can at least delete the line of code that's causing the issue for y'all. (Currently it looks like skulpt supports numpy but it doesn't say anything about scipy, which is where the linear regression model lives, so I may have to do a bit more work with this bit. Will update.)

I've tested and verified that this allows you to at least proceed through the end of question 2, but it won't work for i18n because that requires a constant-time solution, which is something that needs added.

To that end, I think it's likely better to get constant time working so that we can move through the entire flow, or to remove it altogether.