### PR TITLE
Fix #40: parse all possible JS variables human-readably.

### DIFF
--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -46,6 +46,8 @@ tie.factory('FeedbackGeneratorService', [
         }
         return '{' + humanReadableKeyValuePairs.join(', ') + '}';
       } else {
+        console.error(
+          'Could not make the following object human-readable: ', jsVariable);
         return '[UNKNOWN OBJECT]';
       }
     };

--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -20,21 +20,33 @@
 
 tie.factory('FeedbackGeneratorService', [
   'FeedbackObjectFactory', function(FeedbackObjectFactory) {
+    // TODO(sll): Update this function to take the programming language into
+    // account when generating the human-readable representations. Currently,
+    // it assumes that Python is being used.
     var _jsToHumanReadable = function(jsVariable) {
-      if (typeof jsVariable === 'string') {
+      if (jsVariable === null || jsVariable === undefined) {
+        return 'None';
+      } else if (typeof jsVariable === 'string') {
         return '"' + jsVariable + '"';
       } else if (typeof jsVariable === 'number') {
         return String(jsVariable);
       } else if (typeof jsVariable === 'boolean') {
-        // TODO(sll): Change human-readable representation based on language.
         return jsVariable ? 'True' : 'False';
       } else if (Array.isArray(jsVariable)) {
         var humanReadableElements = jsVariable.map(function(arrayElement) {
           return _jsToHumanReadable(arrayElement);
         });
         return '[' + humanReadableElements.join(', ') + ']';
+      } else if (typeof jsVariable === 'object') {
+        var humanReadableKeyValuePairs = [];
+        for (var key in jsVariable) {
+          humanReadableKeyValuePairs.push(
+            _jsToHumanReadable(key) + ': ' +
+            _jsToHumanReadable(jsVariable[key]));
+        }
+        return '{' + humanReadableKeyValuePairs.join(', ') + '}';
       } else {
-        throw Error('Cannot parse JS variable: ' + jsVariable);
+        return '[UNKNOWN OBJECT]';
       }
     };
 

--- a/client/services/FeedbackGeneratorServiceSpec.js
+++ b/client/services/FeedbackGeneratorServiceSpec.js
@@ -27,8 +27,14 @@ describe('FeedbackGeneratorService', function() {
   }));
 
   describe('_jsToHumanReadable', function() {
-    it('should return "stringified" (readable) versions of input variables', 
+    it('should return "stringified" (readable) versions of input variables',
       function() {
+      expect(
+        FeedbackGeneratorService._jsToHumanReadable(null)
+      ).toEqual('None');
+      expect(
+        FeedbackGeneratorService._jsToHumanReadable(undefined)
+      ).toEqual('None');
       expect(
         FeedbackGeneratorService._jsToHumanReadable('cat')
       ).toEqual('"cat"');
@@ -44,6 +50,9 @@ describe('FeedbackGeneratorService', function() {
       expect(
         FeedbackGeneratorService._jsToHumanReadable([1, 3, 5])
       ).toEqual('[1, 3, 5]');
+      expect(
+        FeedbackGeneratorService._jsToHumanReadable({a: 3, b: 5, c: 'j'})
+      ).toEqual('{"a": 3, "b": 5, "c": "j"}');
     });
   });
 


### PR DESCRIPTION
Note: this also fixes the error @apicardgoog reported where typing "return {}" results in no error and no system feedback.