### PR TITLE
Fix the ui issue caused by horizontal scrolling in editor. (#108)

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -445,7 +445,8 @@ tie.directive('learnerView', [function() {
           lineNumbers: true,
           mode: LANGUAGE_PYTHON,
           smartIndent: true,
-          tabSize: 4
+          tabSize: 4,
+          fixedGutter: false
         };
 
         $scope.showNextTask = function() {


### PR DESCRIPTION
Now the code doesn't overlap with line number. However, the line number will be hidden if the line is too long. I'm not sure if this introduces a new issue.


![screen shot 2017-04-04 at 2 45 07 pm](https://cloud.githubusercontent.com/assets/5546251/24680517/0efa3448-1946-11e7-8e31-dd0d2380e115.png)
