### PR TITLE
Fixed random text appearing when undo from default code

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -59,10 +59,9 @@ tie.directive('learnerView', [function() {
             <div class="tie-coding-window">
               <div class="tie-lang-terminal">
                 <div class="tie-coding-terminal">
-                  <ui-codemirror ui-codemirror="codeMirrorOptions"
+                  <ui-codemirror ui-codemirror-opts="codeMirrorOptions"
                       ng-model="code"
-                      class="tie-codemirror-container">
-                  </ui-codemirror>
+                      class="tie-codemirror-container"></ui-codemirror>
                 </div>
                 <select class="tie-lang-select-menu" name="lang-select-menu">
                   <option value="Python" selected>Python</option>


### PR DESCRIPTION
Resolving #92 

Bug on line 62 - look [here](https://github.com/angular-ui/ui-codemirror#options) for reference
The blank line and space characters just before closing the ui-codemirror tag are preserved, and after undo is used they appear in the code instead of a blank editor.