### PR TITLE
Fix #154: Show check mark instead of number when question is completed.

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -29,7 +29,8 @@ tie.directive('learnerView', [function() {
                   ng-repeat="questionId in questionIds track by $index"
                   ng-click="navigateToQuestion($index)">
                 <div class="tie-step-circle" ng-class="{'tie-step-active': currentQuestionIndex === $index, 'tie-step-unlocked': questionsCompletionStatus[$index]}">
-                  <span class="tie-step-text">{{$index + 1}}</span>
+                  <span class="tie-step-text", ng-show="!questionsCompletionStatus[$index]">{{$index + 1}}</span>
+                  <span class="tie-step-checkmark, ng-hide", ng-show="questionsCompletionStatus[$index]">&#10003;</span>
                 </div>
                 <div ng-class="{'tie-step-line': $index < (questionIds.length - 1)}"></div>
               </div>
@@ -328,7 +329,7 @@ tie.directive('learnerView', [function() {
           margin-top: auto;
           width: 128px;
         }
-        .tie-step-text {
+        .tie-step-text, .tie-step-checkmark {
           font-size: 14px;
           vertical-align: middle;
         }

--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -30,7 +30,7 @@ tie.directive('learnerView', [function() {
                   ng-click="navigateToQuestion($index)">
                 <div class="tie-step-circle" ng-class="{'tie-step-active': currentQuestionIndex === $index, 'tie-step-unlocked': questionsCompletionStatus[$index]}">
                   <span class="tie-step-text", ng-show="!questionsCompletionStatus[$index]">{{$index + 1}}</span>
-                  <span class="tie-step-checkmark, ng-hide", ng-show="questionsCompletionStatus[$index]">&#10003;</span>
+                  <span class="tie-step-checkmark", ng-show="questionsCompletionStatus[$index]">&#10004;</span>
                 </div>
                 <div ng-class="{'tie-step-line': $index < (questionIds.length - 1)}"></div>
               </div>
@@ -329,7 +329,7 @@ tie.directive('learnerView', [function() {
           margin-top: auto;
           width: 128px;
         }
-        .tie-step-text, .tie-step-checkmark {
+        .tie-step-checkmark, .tie-step-text {
           font-size: 14px;
           vertical-align: middle;
         }


### PR DESCRIPTION
The representation turns to a check mark when the question is completed. 

Screenshot:

![screen shot 2017-04-06 at 11 41 23 am](https://cloud.githubusercontent.com/assets/5546251/24770338/79031ac0-1abe-11e7-8f8e-2bf18d9a7ea7.png)
