### PR TITLE
[Fix #98 issue] Add local storage to retrieve submitted code

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -379,9 +379,12 @@ tie.directive('learnerView', [function() {
           currentTaskIndex = 0;
           $scope.title = question.getTitle();
           $scope.code = question.getStarterCode(language);
-          // Check if there is any previously stored code and retrieve it.          
-          if (localStorage.getItem("question_code_" + $scope.currentQuestionIndex)) {
-            $scope.code = localStorage.getItem("question_code_" + $scope.currentQuestionIndex);
+          // Check if there is any previously stored 
+          // code and retrieve it.          
+          if (localStorage.getItem("question_code_" + 
+            $scope.currentQuestionIndex)) {
+            $scope.code = localStorage.getItem("question_code_" + 
+                $scope.currentQuestionIndex);
           }
           $scope.instructions = tasks[currentTaskIndex].getInstructions();
           $scope.previousInstructions = [];
@@ -475,7 +478,8 @@ tie.directive('learnerView', [function() {
 
         $scope.submitCode = function(code) {
           // Store the current code every time the code is submitted
-          localStorage.setItem("question_code_" + $scope.currentQuestionIndex, code);
+          localStorage.setItem("question_code_" + 
+            $scope.currentQuestionIndex, code);
           $scope.loadingIndicatorIsShown = true;
           var additionalHeightForLoadingIndicator = 17;
           $timeout(function() {

--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -29,8 +29,7 @@ tie.directive('learnerView', [function() {
                   ng-repeat="questionId in questionIds track by $index"
                   ng-click="navigateToQuestion($index)">
                 <div class="tie-step-circle" ng-class="{'tie-step-active': currentQuestionIndex === $index, 'tie-step-unlocked': questionsCompletionStatus[$index]}">
-                  <span class="tie-step-text", ng-show="!questionsCompletionStatus[$index]">{{$index + 1}}</span>
-                  <span class="tie-step-checkmark", ng-show="questionsCompletionStatus[$index]">&#10004;</span>
+                  <span class="tie-step-text">{{$index + 1}}</span>
                 </div>
                 <div ng-class="{'tie-step-line': $index < (questionIds.length - 1)}"></div>
               </div>
@@ -329,7 +328,7 @@ tie.directive('learnerView', [function() {
           margin-top: auto;
           width: 128px;
         }
-        .tie-step-checkmark, .tie-step-text {
+        .tie-step-text {
           font-size: 14px;
           vertical-align: middle;
         }
@@ -380,6 +379,10 @@ tie.directive('learnerView', [function() {
           currentTaskIndex = 0;
           $scope.title = question.getTitle();
           $scope.code = question.getStarterCode(language);
+          // Check if there is any previously stored code and retrieve it.          
+          if (localStorage.getItem("question_code_" + $scope.currentQuestionIndex)) {
+            $scope.code = localStorage.getItem("question_code_" + $scope.currentQuestionIndex);
+          }
           $scope.instructions = tasks[currentTaskIndex].getInstructions();
           $scope.previousInstructions = [];
           $scope.nextButtonIsShown = false;
@@ -471,6 +474,8 @@ tie.directive('learnerView', [function() {
         };
 
         $scope.submitCode = function(code) {
+          // Store the current code every time the code is submitted
+          localStorage.setItem("question_code_" + $scope.currentQuestionIndex, code);
           $scope.loadingIndicatorIsShown = true;
           var additionalHeightForLoadingIndicator = 17;
           $timeout(function() {


### PR DESCRIPTION
#98 
Currently, only submitted code can be saved and retrieved.
Alternatively, we may use setInterval to periodically save the code

1. Put some code and **Run**:
![image](https://cloud.githubusercontent.com/assets/16668475/24777637/1d69e956-1adb-11e7-9e53-6a4693f949ab.png)

2. Switch to another question.

3. Switch back and see the restored code:
![image](https://cloud.githubusercontent.com/assets/16668475/24777646/2abd4382-1adb-11e7-8482-bf25f197115d.png)

