### PR TITLE
Add feature to correctness test: support comparing list of strings

### DIFF
--- a/client/domain/CorrectnessTestObjectFactory.js
+++ b/client/domain/CorrectnessTestObjectFactory.js
@@ -31,18 +31,9 @@ tie.factory('CorrectnessTestObjectFactory', [
     };
 
     CorrectnessTest.prototype.matchesOutput = function(output) {
-    // If allowOutputs should be arrays and learner's code returns an array
-    // Then the if statement will check if learner's output matches
-    // any of arrays in the allowedOutputs
-      if (this._allowedOutputs.length > 0 && 
-          angular.isArray(this._allowedOutputs[0]) &&
-          angular.isArray(output)) {
-        var stringifiedOutput = JSON.stringify(output);
-        return this._allowedOutputs.some(function(allowedOutput) {
-          return JSON.stringify(allowedOutput) === stringifiedOutput;
-        });
-      }
-      return this._allowedOutputs.indexOf(output) !== -1;
+      return this._allowedOutputs.some(function(allowedOutput) {
+        return angular.equals(allowedOutput, output);
+      });
     };
 
     CorrectnessTest.prototype.getAnyAllowedOutput = function() {

--- a/client/domain/CorrectnessTestObjectFactory.js
+++ b/client/domain/CorrectnessTestObjectFactory.js
@@ -31,6 +31,20 @@ tie.factory('CorrectnessTestObjectFactory', [
     };
 
     CorrectnessTest.prototype.matchesOutput = function(output) {
+    // If allowOutputs should be arrays and learner's code returns an array
+      if (this._allowedOutputs.length > 0 && 
+        this._allowedOutputs[0] instanceof Array &&
+        output instanceof Array) { 
+      // Stringify the arrays and then compare
+        var stringifiedOutput = JSON.stringify(output);
+        for (var i = 0, l = this._allowedOutputs.length; i < l; i++) {
+          if (JSON.stringify(this._allowedOutputs[i]) === stringifiedOutput) {
+            return true;
+          }
+        }
+      // If output matches none allowedOutputs
+        return false; 
+      }
       return this._allowedOutputs.indexOf(output) !== -1;
     };
 

--- a/client/domain/CorrectnessTestObjectFactory.js
+++ b/client/domain/CorrectnessTestObjectFactory.js
@@ -35,17 +35,12 @@ tie.factory('CorrectnessTestObjectFactory', [
     // Then the if statement will check if learner's output matches
     // any of arrays in the allowedOutputs
       if (this._allowedOutputs.length > 0 && 
-        this._allowedOutputs[0] instanceof Array &&
-        output instanceof Array) { 
-      // Stringify the arrays and then compare
+          angular.isArray(this._allowedOutputs[0]) &&
+          angular.isArray(output)) {
         var stringifiedOutput = JSON.stringify(output);
-        for (var i = 0, l = this._allowedOutputs.length; i < l; i++) {
-          if (JSON.stringify(this._allowedOutputs[i]) === stringifiedOutput) {
-            return true;
-          }
-        }
-      // If output matches none allowedOutputs
-        return false; 
+        return this._allowedOutputs.some(function(allowedOutput) {
+          return JSON.stringify(allowedOutput) === stringifiedOutput;
+        });
       }
       return this._allowedOutputs.indexOf(output) !== -1;
     };

--- a/client/domain/CorrectnessTestObjectFactory.js
+++ b/client/domain/CorrectnessTestObjectFactory.js
@@ -32,6 +32,8 @@ tie.factory('CorrectnessTestObjectFactory', [
 
     CorrectnessTest.prototype.matchesOutput = function(output) {
     // If allowOutputs should be arrays and learner's code returns an array
+    // Then the if statement will check if learner's output matches
+    // any of arrays in the allowedOutputs
       if (this._allowedOutputs.length > 0 && 
         this._allowedOutputs[0] instanceof Array &&
         output instanceof Array) { 


### PR DESCRIPTION
Now, learner's code can output list of strings and correctness test will be able to return `True` if any of the allowedOutputs has the same strings (and in same order) as list of strings that learner's code output. 

The approach is to stringify list of strings so that they can be compared. 