### PR TITLE
get question IDs from keys of question dict.

### DIFF
--- a/assets/tests/QuestionSchemaValidationServiceSpec.js
+++ b/assets/tests/QuestionSchemaValidationServiceSpec.js
@@ -25,9 +25,7 @@ describe('QuestionSchemaValidationService', function() {
   // Update if you add new question schema tests.
   var EXPECTED_VERIFIER_FUNCTION_COUNT = 12;
   // Should contain all question IDs.
-  // TODO(eyurko): Figure out a way to dynamically check to make sure
-  // that all question IDs are specified.
-  var QUESTION_IDS = ['reverseWords', 'parens', 'i18n', 'rle'];
+  var QUESTION_IDS = Object.keys(globalData.questions);
 
   beforeEach(module('tie'));
   beforeEach(inject(function($injector) {


### PR DESCRIPTION
A new key-value pair is added to globalData.questions in each &lt;question>.js file. Thus we can get the list of question IDs from keys of globalData.questions, I guess?