### PR TITLE
Fix #225: Add tests in client/services/code_preprocessors

### DIFF
--- a/client/services/code_preprocessors/CodePreprocessorDispatcherServiceSpec.js
+++ b/client/services/code_preprocessors/CodePreprocessorDispatcherServiceSpec.js
@@ -1,0 +1,55 @@
+// Copyright 2017 The TIE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for the CodePreprocessorDispatcherService.
+ */
+
+describe('CodePreprocessorDispatcherService', function() {
+  var CodePreprocessorDispatcherService;
+  var PythonCodePreprocessorService;
+  var LANGUAGE_PYTHON;
+  var CodeSubmissionObjectFactory;
+
+
+  beforeEach(module('tie'));
+  beforeEach(inject(function($injector) {
+    CodePreprocessorDispatcherService = $injector.get(
+      'CodePreprocessorDispatcherService');
+    PythonCodePreprocessorService = $injector.get(
+      'PythonCodePreprocessorService');
+    LANGUAGE_PYTHON = $injector.get('LANGUAGE_PYTHON');
+    CodeSubmissionObjectFactory = $injector.get('CodeSubmissionObjectFactory');
+  }));
+
+  describe('preprocess', function() {
+    it('should throw error of Language not supported', function() {
+      var unsupportedLanguage = "someLanguage";
+      var failFunction = function() {
+        CodePreprocessorDispatcherService.preprocess(unsupportedLanguage,
+        '', '', '', '', '', '', '', '');
+      };
+      expect(failFunction).toThrow(new Error("Language not supported: "
+                                              + unsupportedLanguage));
+    });
+    it('should preprocess python source code', function(){
+      var codeSubmission = CodeSubmissionObjectFactory.create('a = 1\nb= 2');
+      var originProcessedCode = codeSubmission.getPreprocessedCode();
+      CodePreprocessorDispatcherService.preprocess(LANGUAGE_PYTHON,
+        codeSubmission, '', '', '', '', [], [], []);
+      expect(codeSubmission.getPreprocessedCode())
+        .not.toEqual(originProcessedCode);
+    });
+  });
+});

--- a/client/services/code_preprocessors/CodePreprocessorDispatcherServiceSpec.js
+++ b/client/services/code_preprocessors/CodePreprocessorDispatcherServiceSpec.js
@@ -34,13 +34,14 @@ describe('CodePreprocessorDispatcherService', function() {
   }));
 
   describe('preprocess', function() {
-    it('should throw error of Language not supported', function() {
+    it('should throw an error if the language passed in is not supported',
+      function() {
       var unsupportedLanguage = "someLanguage";
-      var failFunction = function() {
+      var failingFunction = function() {
         CodePreprocessorDispatcherService.preprocess(unsupportedLanguage,
         '', '', '', '', '', '', '', '');
       };
-      expect(failFunction).toThrow(new Error("Language not supported: "
+      expect(failingFunction).toThrow(new Error("Language not supported: "
                                               + unsupportedLanguage));
     });
     it('should preprocess python source code', function(){
@@ -53,3 +54,4 @@ describe('CodePreprocessorDispatcherService', function() {
     });
   });
 });
+

--- a/client/services/code_preprocessors/PythonCodePreprocessorService.js
+++ b/client/services/code_preprocessors/PythonCodePreprocessorService.js
@@ -149,7 +149,6 @@ tie.factory('PythonCodePreprocessorService', [
           lastFunctionNameLocation += codeToAdd.length + 1;
         }
       }
-      return code;
     };
 
     var _generateCorrectnessTestCode = function(
@@ -195,7 +194,7 @@ tie.factory('PythonCodePreprocessorService', [
       // TODO(sll): Cache the results of running the buggy code, so that they
       // don't have to be recomputed for every run.
       var testInputCode = (
-        inputFunctionName ? 
+        inputFunctionName ?
         inputFunctionName + '(test_input)' :
         'test_input'
       );

--- a/client/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
+++ b/client/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
@@ -41,6 +41,18 @@ describe('PythonCodePreprocessorService', function() {
       ).toEqual("'stringify'");
     });
 
+    it('should correctly convert a json String with back slashes', function() {
+      expect(
+        PythonCodePreprocessorService._jsonVariableToPython('strin\\gify')
+      ).toEqual("'strin\\\\gify'");
+    });
+
+    it('should correctly convert a json number to a Python number', function() {
+      expect(
+        PythonCodePreprocessorService._jsonVariableToPython(12)
+      ).toEqual(12);
+    });
+
     it(
       [
         'should correctly convert a json Array to a string version ',
@@ -68,6 +80,15 @@ describe('PythonCodePreprocessorService', function() {
         PythonCodePreprocessorService._jsonVariableToPython(
           [[true, true], [false, false], [true, false]])
       ).toEqual("[[True, True], [False, False], [True, False]]");
+    });
+
+    it('should throw error for unsupported inputs', function() {
+      var errorMsg = "Only string, array, and boolean inputs are supported.";
+      expect(function() {
+        PythonCodePreprocessorService._jsonVariableToPython({
+          "foo": "val"
+        });
+      }).toThrow(new Error(errorMsg));
     });
   });
 

--- a/client/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
+++ b/client/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
@@ -35,19 +35,21 @@ describe('PythonCodePreprocessorService', function() {
   }));
 
   describe('_jsonVariableToPython', function() {
-    it('should correctly convert a json String to a Python string', function() {
+    it('should correctly convert a JSON String to a Python string', function() {
       expect(
         PythonCodePreprocessorService._jsonVariableToPython('stringify')
       ).toEqual("'stringify'");
     });
 
-    it('should correctly convert a json String with back slashes', function() {
+    it('should correctly convert a JSON string with escaped characters',
+      function() {
       expect(
         PythonCodePreprocessorService._jsonVariableToPython('strin\\gify')
       ).toEqual("'strin\\\\gify'");
     });
 
-    it('should correctly convert a json number to a Python number', function() {
+    it('should correctly convert a JSON integer to a Python integer',
+      function() {
       expect(
         PythonCodePreprocessorService._jsonVariableToPython(12)
       ).toEqual(12);
@@ -55,7 +57,7 @@ describe('PythonCodePreprocessorService', function() {
 
     it(
       [
-        'should correctly convert a json Array to a string version ',
+        'should correctly convert a JSON Array to a string version ',
         'of a Python array'
       ].join('') , function() {
       expect(
@@ -63,7 +65,7 @@ describe('PythonCodePreprocessorService', function() {
       ).toEqual("['cat', '2', '3']");
     });
 
-    it('should correctly convert a nested json Array to a similar Python array'
+    it('should correctly convert a nested JSON Array to a similar Python array'
       , function() {
       expect(
         PythonCodePreprocessorService._jsonVariableToPython(
@@ -73,7 +75,7 @@ describe('PythonCodePreprocessorService', function() {
 
     it(
       [
-        'should correctly convert a json boolean Array to a string version ',
+        'should correctly convert a JSON boolean Array to a string version ',
         'of a Python boolean array'
       ].join('') , function() {
       expect(
@@ -82,7 +84,7 @@ describe('PythonCodePreprocessorService', function() {
       ).toEqual("[[True, True], [False, False], [True, False]]");
     });
 
-    it('should throw error for unsupported inputs', function() {
+    it('should throw an error if the input type is unsupported', function() {
       var errorMsg = "Only string, array, and boolean inputs are supported.";
       expect(function() {
         PythonCodePreprocessorService._jsonVariableToPython({

--- a/client/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
+++ b/client/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
@@ -35,7 +35,7 @@ describe('PythonCodePreprocessorService', function() {
   }));
 
   describe('_jsonVariableToPython', function() {
-    it('should correctly convert a JSON String to a Python string', function() {
+    it('should correctly convert a JSON string to a Python string', function() {
       expect(
         PythonCodePreprocessorService._jsonVariableToPython('stringify')
       ).toEqual("'stringify'");
@@ -57,7 +57,7 @@ describe('PythonCodePreprocessorService', function() {
 
     it(
       [
-        'should correctly convert a JSON Array to a string version ',
+        'should correctly convert a JSON array to a string version ',
         'of a Python array'
       ].join('') , function() {
       expect(
@@ -65,7 +65,7 @@ describe('PythonCodePreprocessorService', function() {
       ).toEqual("['cat', '2', '3']");
     });
 
-    it('should correctly convert a nested JSON Array to a similar Python array'
+    it('should correctly convert a nested JSON array to a similar Python array'
       , function() {
       expect(
         PythonCodePreprocessorService._jsonVariableToPython(
@@ -75,7 +75,7 @@ describe('PythonCodePreprocessorService', function() {
 
     it(
       [
-        'should correctly convert a JSON boolean Array to a string version ',
+        'should correctly convert a JSON boolean array to a string version ',
         'of a Python boolean array'
       ].join('') , function() {
       expect(


### PR DESCRIPTION
Fix #225 

Note: Seems that this is [line of code](https://github.com/google/tie/blob/master/client/services/code_preprocessors/PythonCodePreprocessorService.js#L152) will never be executed(which prevents 100% coverage of course).

There is nowhere to break the `while(true)` loop. I think it's safe to delete this line.