### PR TITLE
Fix #157: Give graduated feedback for syntax errors.

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -35,92 +35,92 @@ tie.directive('learnerView', [function() {
                   </div>
                   <div ng-class="{'tie-step-line': $index < (questionIds.length - 1)}"></div>
                 </div>
-                <div ng-class="{'tie-step-line': $index < (questionIds.length - 1)}"></div>
               </div>
             </div>
           </div>
-            <div class="tie-coding-ui">
-              <div class="tie-feedback-window" ng-class="{'night-mode': isInDarkMode}">
-                <div class="tie-feedback">
-                  <p ng-repeat="paragraph in feedbackParagraphs track by $index"
-                     class="tie-feedback-paragraph"
-                     ng-class="{'tie-feedback-paragraph-code': paragraph.isCodeParagraph()}">
-                    <span ng-if="$first">{{feedbackTimestamp}}</span>
-                    <span ng-if="paragraph.isTextParagraph()">
-                      {{paragraph.getContent()}}
-                    </span>
-                    <span ng-if="paragraph.isCodeParagraph()">
-                      <code-snippet content="paragraph.getContent()"></code-snippet>
-                    </span>
-                  </p>
-                </div>
-                <div class="tie-feedback-syntax-error">
-                <a href class="tie-feedback-syntax-error-link", ng-click="toggleSyntaxErrorHint()", 
-                        ng-show="isSyntaxErrorLinkShown">
+          <div class="tie-coding-ui">
+            <div class="tie-feedback-window" ng-class="{'night-mode': isInDarkMode}">
+              <div class="tie-feedback">
+                <p ng-repeat="paragraph in feedbackParagraphs track by $index"
+                    class="tie-feedback-paragraph"
+                    ng-class="{'tie-feedback-paragraph-code': paragraph.isCodeParagraph()}">
+                  <span ng-if="$first">{{feedbackTimestamp}}</span>
+                  <span ng-if="paragraph.isTextParagraph()">
+                    {{paragraph.getContent()}}
+                  </span>
+                  <span ng-if="paragraph.isCodeParagraph()">
+                    <code-snippet content="paragraph.getContent()"></code-snippet>
+                  </span>
+                </p>
+              </div>
+              <div class="tie-feedback-syntax-error">
+                <a href class="tie-feedback-syntax-error-link",
+                   ng-click="toggleSyntaxErrorHint()",
+                   ng-show="syntaxErrorFound">
                   {{isSyntaxErrorShown ? 'Hide error details' : 'Display error details'}}
                 </a>
               </div>
-              <p class = "tie-feedback-error-string", ng-show="isSyntaxErrorShown">
+              <br>
+              <span class = "tie-feedback-error-string", ng-show="isSyntaxErrorShown">
                 {{syntaxErrorString}}
-              </p>
-                <div class="tie-dot-container" ng-if="loadingIndicatorIsShown">
-                  <div class="tie-dot tie-dot-1" ng-class="{'night-mode': isInDarkMode}"></div>
-                  <div class="tie-dot tie-dot-2" ng-class="{'night-mode': isInDarkMode}"></div>
-                  <div class="tie-dot tie-dot-3" ng-class="{'night-mode': isInDarkMode}"></div>
-                </div>
+              </span>
+              <div class="tie-dot-container" ng-if="loadingIndicatorIsShown">
+                <div class="tie-dot tie-dot-1" ng-class="{'night-mode': isInDarkMode}"></div>
+                <div class="tie-dot tie-dot-2" ng-class="{'night-mode': isInDarkMode}"></div>
+                <div class="tie-dot tie-dot-3" ng-class="{'night-mode': isInDarkMode}"></div>
               </div>
-              <div class="tie-coding-window">
-                <div class="tie-lang-terminal">
-                  <div class="tie-coding-terminal">
-                    <ui-codemirror ui-codemirror-opts="codeMirrorOptions"
-                        ng-model="code"
-                        class="tie-codemirror-container"></ui-codemirror>
-                  </div>
-                  <select class="tie-lang-select-menu" name="lang-select-menu">
-                    <option value="Python" selected>Python</option>
-                  </select>
-                  <select class="tie-theme-select" name="theme-select" 
-                          ng-change="changeTheme()" ng-model="theme"
-                          ng-options="i.themeName as i.themeName for i in themes">
-                    <option style="display: none" value="">Theme</option>
-                    <option></option>
-                  </select>     
-                  <button class="tie-code-reset" name="code-reset"
-                      ng-click="resetCode()">
-                    Reset Code
-                  </button>
-                  <div class="tie-code-auto-save" ng-show="autosaveTextIsDisplayed">
-                    Saving code now...
-                  </div>
-                  <button class="tie-run-button"
-                      ng-class="{'active': !nextButtonIsShown}"
-                      ng-click="submitCode(code)"
-                      ng-disabled="nextButtonIsShown">
-                    Run
-                  </button>
-                  <div class="tie-next-curtain-container"
-                      ng-if="nextButtonIsShown">
-                    <div class="tie-next-curtain"></div>
-                    <div class="tie-arrow-highlighter"></div>
-                    <div ng-click="showNextTask()" class="tie-next-arrow">
-                      <span class="tie-next-button-text">Next</span>
-                    </div>
+            </div>
+            <div class="tie-coding-window">
+              <div class="tie-lang-terminal">
+                <div class="tie-coding-terminal">
+                  <ui-codemirror ui-codemirror-opts="codeMirrorOptions"
+                      ng-model="code"
+                      class="tie-codemirror-container"></ui-codemirror>
+                </div>
+                <select class="tie-lang-select-menu" name="lang-select-menu">
+                  <option value="Python" selected>Python</option>
+                </select>
+                <select class="tie-theme-select" name="theme-select" 
+                        ng-change="changeTheme()" ng-model="theme"
+                        ng-options="i.themeName as i.themeName for i in themes">
+                  <option style="display: none" value="">Theme</option>
+                  <option></option>
+                </select>     
+                <button class="tie-code-reset" name="code-reset"
+                    ng-click="resetCode()">
+                  Reset Code
+                </button>
+                <div class="tie-code-auto-save" ng-show="autosaveTextIsDisplayed">
+                  Saving code now...
+                </div>
+                <button class="tie-run-button"
+                    ng-class="{'active': !nextButtonIsShown}"
+                    ng-click="submitCode(code)"
+                    ng-disabled="nextButtonIsShown">
+                  Run
+                </button>
+                <div class="tie-next-curtain-container"
+                    ng-if="nextButtonIsShown">
+                  <div class="tie-next-curtain"></div>
+                  <div class="tie-arrow-highlighter"></div>
+                  <div ng-click="showNextTask()" class="tie-next-arrow">
+                    <span class="tie-next-button-text">Next</span>
                   </div>
                 </div>
               </div>
             </div>
-            <div class="tie-question-ui">
-              <div class="tie-question-window" ng-class="{'night-mode': isInDarkMode}">
-                <h3 class="tie-question-title">{{title}}</h3>
-                <div class="tie-previous-instructions">
-                  <div ng-repeat="previousInstruction in previousInstructions track by $index">
-                    <p ng-repeat="paragraph in previousInstruction track by $index">{{paragraph}}</p>
-                    <hr>
-                  </div>
+          </div>
+          <div class="tie-question-ui">
+            <div class="tie-question-window" ng-class="{'night-mode': isInDarkMode}">
+              <h3 class="tie-question-title">{{title}}</h3>
+              <div class="tie-previous-instructions">
+                <div ng-repeat="previousInstruction in previousInstructions track by $index">
+                  <p ng-repeat="paragraph in previousInstruction track by $index">{{paragraph}}</p>
+                  <hr>
                 </div>
-                <div class="tie-instructions">
-                  <p ng-repeat="paragraph in instructions">{{paragraph}}</p>
-                </div>
+              </div>
+              <div class="tie-instructions">
+                <p ng-repeat="paragraph in instructions">{{paragraph}}</p>
               </div>
             </div>
           </div>
@@ -215,17 +215,6 @@ tie.directive('learnerView', [function() {
         }
         .tie-dot-3 {
           -webkit-animation-delay: 0.2s;
-        }
-        .tie-question-ui-inner {
-          padding-left: 32px;
-          padding-right: 32px;
-          white-space: nowrap;
-        }
-        .tie-question-ui-outer {
-          display: table;
-          margin-left: auto;
-          margin-right: auto;
-          margin-top: 16px;
         }
         .tie-feedback-error-string {
           color: #FF0000;
@@ -500,7 +489,7 @@ tie.directive('learnerView', [function() {
         };
 
         var hideSyntaxErrorLink = function() {
-          $scope.isSyntaxErrorLinkShown = false;
+          $scope.syntaxErrorFound = false;
         };
 
         var setFeedback = function(feedback) {
@@ -533,11 +522,11 @@ tie.directive('learnerView', [function() {
             var syntaxErrorIndex = feedback.getSyntaxErrorIndex();
             // The index must be either null(indicating no syntax error)
             // or a positive integer.
-            if (syntaxErrorIndex) {
+            if (typeof syntaxErrorIndex === 'number' && syntaxErrorIndex > 0) {
               var syntaxErrorParagraph = feedbackParagraphs[syntaxErrorIndex];
               feedbackParagraphs.splice(syntaxErrorIndex, 1);
               $scope.syntaxErrorString = syntaxErrorParagraph.getContent();
-              $scope.isSyntaxErrorLinkShown = true;
+              $scope.syntaxErrorFound = true;
             }
             $scope.feedbackParagraphs = feedbackParagraphs;
           }

--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -37,90 +37,90 @@ tie.directive('learnerView', [function() {
                 </div>
               </div>
             </div>
-          </div>
-          <div class="tie-coding-ui">
-            <div class="tie-feedback-window" ng-class="{'night-mode': isInDarkMode}">
-              <div class="tie-feedback">
-                <p ng-repeat="paragraph in feedbackParagraphs track by $index"
-                    class="tie-feedback-paragraph"
-                    ng-class="{'tie-feedback-paragraph-code': paragraph.isCodeParagraph()}">
-                  <span ng-if="$first">{{feedbackTimestamp}}</span>
-                  <span ng-if="paragraph.isTextParagraph()">
-                    {{paragraph.getContent()}}
-                  </span>
-                  <span ng-if="paragraph.isCodeParagraph()">
-                    <code-snippet content="paragraph.getContent()"></code-snippet>
-                  </span>
-                </p>
-              </div>
-              <div class="tie-feedback-syntax-error">
-                <a href class="tie-feedback-syntax-error-link",
-                   ng-click="toggleSyntaxErrorHint()",
-                   ng-show="syntaxErrorFound">
-                  {{isSyntaxErrorShown ? 'Hide error details' : 'Display error details'}}
-                </a>
-              </div>
-              <br>
-              <span class = "tie-feedback-error-string", ng-show="isSyntaxErrorShown">
-                {{syntaxErrorString}}
-              </span>
-              <div class="tie-dot-container" ng-if="loadingIndicatorIsShown">
-                <div class="tie-dot tie-dot-1" ng-class="{'night-mode': isInDarkMode}"></div>
-                <div class="tie-dot tie-dot-2" ng-class="{'night-mode': isInDarkMode}"></div>
-                <div class="tie-dot tie-dot-3" ng-class="{'night-mode': isInDarkMode}"></div>
-              </div>
-            </div>
-            <div class="tie-coding-window">
-              <div class="tie-lang-terminal">
-                <div class="tie-coding-terminal">
-                  <ui-codemirror ui-codemirror-opts="codeMirrorOptions"
-                      ng-model="code"
-                      class="tie-codemirror-container"></ui-codemirror>
+            <div class="tie-coding-ui">
+              <div class="tie-feedback-window" ng-class="{'night-mode': isInDarkMode}">
+                <div class="tie-feedback">
+                  <p ng-repeat="paragraph in feedbackParagraphs track by $index"
+                      class="tie-feedback-paragraph"
+                      ng-class="{'tie-feedback-paragraph-code': paragraph.isCodeParagraph()}">
+                    <span ng-if="$first">{{feedbackTimestamp}}</span>
+                    <span ng-if="paragraph.isTextParagraph()">
+                      {{paragraph.getContent()}}
+                    </span>
+                    <span ng-if="paragraph.isCodeParagraph()">
+                      <code-snippet content="paragraph.getContent()"></code-snippet>
+                    </span>
+                  </p>
                 </div>
-                <select class="tie-lang-select-menu" name="lang-select-menu">
-                  <option value="Python" selected>Python</option>
-                </select>
-                <select class="tie-theme-select" name="theme-select" 
-                        ng-change="changeTheme()" ng-model="theme"
-                        ng-options="i.themeName as i.themeName for i in themes">
-                  <option style="display: none" value="">Theme</option>
-                  <option></option>
-                </select>     
-                <button class="tie-code-reset" name="code-reset"
-                    ng-click="resetCode()">
-                  Reset Code
-                </button>
-                <div class="tie-code-auto-save" ng-show="autosaveTextIsDisplayed">
-                  Saving code now...
+                <div class="tie-feedback-syntax-error">
+                  <a href class="tie-feedback-syntax-error-link",
+                      ng-click="toggleSyntaxErrorHint()",
+                      ng-show="syntaxErrorFound">
+                    {{isSyntaxErrorShown ? 'Hide error details' : 'Display error details'}}
+                  </a>
                 </div>
-                <button class="tie-run-button"
-                    ng-class="{'active': !nextButtonIsShown}"
-                    ng-click="submitCode(code)"
-                    ng-disabled="nextButtonIsShown">
-                  Run
-                </button>
-                <div class="tie-next-curtain-container"
-                    ng-if="nextButtonIsShown">
-                  <div class="tie-next-curtain"></div>
-                  <div class="tie-arrow-highlighter"></div>
-                  <div ng-click="showNextTask()" class="tie-next-arrow">
-                    <span class="tie-next-button-text">Next</span>
+                <br>
+                <span class = "tie-feedback-error-string", ng-show="isSyntaxErrorShown">
+                  {{syntaxErrorString}}
+                </span>
+                <div class="tie-dot-container" ng-if="loadingIndicatorIsShown">
+                  <div class="tie-dot tie-dot-1" ng-class="{'night-mode': isInDarkMode}"></div>
+                  <div class="tie-dot tie-dot-2" ng-class="{'night-mode': isInDarkMode}"></div>
+                  <div class="tie-dot tie-dot-3" ng-class="{'night-mode': isInDarkMode}"></div>
+                </div>
+              </div>
+              <div class="tie-coding-window">
+                <div class="tie-lang-terminal">
+                  <div class="tie-coding-terminal">
+                    <ui-codemirror ui-codemirror-opts="codeMirrorOptions"
+                        ng-model="code"
+                        class="tie-codemirror-container"></ui-codemirror>
+                  </div>
+                  <select class="tie-lang-select-menu" name="lang-select-menu">
+                    <option value="Python" selected>Python</option>
+                  </select>
+                  <select class="tie-theme-select" name="theme-select" 
+                          ng-change="changeTheme()" ng-model="theme"
+                          ng-options="i.themeName as i.themeName for i in themes">
+                    <option style="display: none" value="">Theme</option>
+                    <option></option>
+                  </select>     
+                  <button class="tie-code-reset" name="code-reset"
+                      ng-click="resetCode()">
+                    Reset Code
+                  </button>
+                  <div class="tie-code-auto-save" ng-show="autosaveTextIsDisplayed">
+                    Saving code now...
+                  </div>
+                  <button class="tie-run-button"
+                      ng-class="{'active': !nextButtonIsShown}"
+                      ng-click="submitCode(code)"
+                      ng-disabled="nextButtonIsShown">
+                    Run
+                  </button>
+                  <div class="tie-next-curtain-container"
+                      ng-if="nextButtonIsShown">
+                    <div class="tie-next-curtain"></div>
+                    <div class="tie-arrow-highlighter"></div>
+                    <div ng-click="showNextTask()" class="tie-next-arrow">
+                      <span class="tie-next-button-text">Next</span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div class="tie-question-ui">
-            <div class="tie-question-window" ng-class="{'night-mode': isInDarkMode}">
-              <h3 class="tie-question-title">{{title}}</h3>
-              <div class="tie-previous-instructions">
-                <div ng-repeat="previousInstruction in previousInstructions track by $index">
-                  <p ng-repeat="paragraph in previousInstruction track by $index">{{paragraph}}</p>
-                  <hr>
+            <div class="tie-question-ui">
+              <div class="tie-question-window" ng-class="{'night-mode': isInDarkMode}">
+                <h3 class="tie-question-title">{{title}}</h3>
+                <div class="tie-previous-instructions">
+                  <div ng-repeat="previousInstruction in previousInstructions track by $index">
+                    <p ng-repeat="paragraph in previousInstruction track by $index">{{paragraph}}</p>
+                    <hr>
+                  </div>
                 </div>
-              </div>
-              <div class="tie-instructions">
-                <p ng-repeat="paragraph in instructions">{{paragraph}}</p>
+                <div class="tie-instructions">
+                  <p ng-repeat="paragraph in instructions">{{paragraph}}</p>
+                </div>
               </div>
             </div>
           </div>

--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -518,7 +518,7 @@ tie.directive('learnerView', [function() {
             var feedbackParagraphs = feedback.getParagraphs();
             // Get the index of syntax error in feedback.
             var syntaxErrorIndex = feedback.getSyntaxErrorIndex();
-            // The index must be either null(indicating no syntax error)
+            // The index must be either null (indicating no syntax error)
             // or a positive integer.
             if (typeof syntaxErrorIndex === 'number' && syntaxErrorIndex > 0) {
               var syntaxErrorParagraph = feedbackParagraphs[syntaxErrorIndex];

--- a/client/domain/FeedbackObjectFactory.js
+++ b/client/domain/FeedbackObjectFactory.js
@@ -25,7 +25,7 @@ tie.factory('FeedbackObjectFactory', [
       // This records what message was displayed with this feedback.
       // If no message was displayed, this will remain null.
       this._hintIndex = null;
-      this._syntaxErrorIndex= null;
+      this._syntaxErrorIndex = null;
     };
 
     // Instance methods.

--- a/client/domain/FeedbackObjectFactory.js
+++ b/client/domain/FeedbackObjectFactory.js
@@ -25,6 +25,7 @@ tie.factory('FeedbackObjectFactory', [
       // This records what message was displayed with this feedback.
       // If no message was displayed, this will remain null.
       this._hintIndex = null;
+      this._syntaxErrorIndex= null;
     };
 
     // Instance methods.
@@ -59,6 +60,14 @@ tie.factory('FeedbackObjectFactory', [
 
     Feedback.prototype.setHintIndex = function(index) {
       this._hintIndex = index;
+    };
+
+    Feedback.prototype.getSyntaxErrorIndex = function() {
+      return this._syntaxErrorIndex;
+    };
+
+    Feedback.prototype.setSyntaxErrorIndex = function(index) {
+      this._syntaxErrorIndex = index;
     };
 
     // Static class methods.

--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -217,7 +217,7 @@ tie.factory('FeedbackGeneratorService', [
       getSyntaxErrorFeedback: function(errorString) {
         var feedback = FeedbackObjectFactory.create(false);
         feedback.appendTextParagraph(
-          "Looks like your code has syntax error. Try to find and fix it.");
+          "Looks like your code has a syntax error. Try to find and fix it.");
         feedback.appendCodeParagraph(errorString);
         feedback.setSyntaxErrorIndex(feedback.getParagraphs().length - 1);
         return feedback;

--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -217,7 +217,7 @@ tie.factory('FeedbackGeneratorService', [
       getSyntaxErrorFeedback: function(errorString) {
         var feedback = FeedbackObjectFactory.create(false);
         feedback.appendTextParagraph(
-          "Looks like your code has a syntax error. Try to find and fix it.");
+          "Looks like your code has a syntax error.");
         feedback.appendCodeParagraph(errorString);
         feedback.setSyntaxErrorIndex(feedback.getParagraphs().length - 1);
         return feedback;

--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -217,8 +217,9 @@ tie.factory('FeedbackGeneratorService', [
       getSyntaxErrorFeedback: function(errorString) {
         var feedback = FeedbackObjectFactory.create(false);
         feedback.appendTextParagraph(
-          "Looks like your code did not compile. Here's the error trace: ");
+          "Looks like your code has syntax error. Try to find and fix it.");
         feedback.appendCodeParagraph(errorString);
+        feedback.setSyntaxErrorIndex(feedback.getParagraphs().length - 1);
         return feedback;
       },
       _getBuggyOutputTestFeedback: _getBuggyOutputTestFeedback,

--- a/client/services/FeedbackGeneratorServiceSpec.js
+++ b/client/services/FeedbackGeneratorServiceSpec.js
@@ -226,7 +226,7 @@ describe('FeedbackGeneratorService', function() {
       expect(paragraphs.length).toEqual(2);
       expect(paragraphs[0].isTextParagraph()).toBe(true);
       expect(paragraphs[0].getContent()).toBe(
-        "Looks like your code did not compile. Here's the error trace: ");
+        "Looks like your code has a syntax error. Try to find and fix it.");
       expect(paragraphs[1].isCodeParagraph()).toBe(true);
       expect(paragraphs[1].getContent()).toBe('some error');
     });

--- a/client/services/FeedbackGeneratorServiceSpec.js
+++ b/client/services/FeedbackGeneratorServiceSpec.js
@@ -226,7 +226,7 @@ describe('FeedbackGeneratorService', function() {
       expect(paragraphs.length).toEqual(2);
       expect(paragraphs[0].isTextParagraph()).toBe(true);
       expect(paragraphs[0].getContent()).toBe(
-        "Looks like your code has a syntax error. Try to find and fix it.");
+        "Looks like your code has a syntax error.");
       expect(paragraphs[1].isCodeParagraph()).toBe(true);
       expect(paragraphs[1].getContent()).toBe('some error');
     });


### PR DESCRIPTION
As we discussed in [this thread](https://github.com/google/tie/issues/157), I talked with several people and finally decided to take your suggestions, which let users make less clicks. 

PTAL(Sorry about the messy diff view after resolving merge conflict.)

Screenshot:
Initial feedback:
![before_run](https://cloud.githubusercontent.com/assets/5546251/25157440/54b9e7ba-2456-11e7-9f3d-2f0879fde00a.png)

Run the code with several syntax errors:
![after_run](https://cloud.githubusercontent.com/assets/5546251/25157456/67fa51c0-2456-11e7-9b17-a9f12743d7d6.png)

Click the link to display error details:
![display_error](https://cloud.githubusercontent.com/assets/5546251/25157460/798fb510-2456-11e7-867e-3b108747c328.png)

Fix the first error and run again(showing the second error detail without having to click the link):
![fix_and_run](https://cloud.githubusercontent.com/assets/5546251/25157468/876a9fba-2456-11e7-861a-9b0e9749a482.png)

Hide the error details:
![hide_error](https://cloud.githubusercontent.com/assets/5546251/25157483/a54bdfc6-2456-11e7-9613-fadefce2968f.png)

Fix the error:
![no_error](https://cloud.githubusercontent.com/assets/5546251/25157487/adaa9996-2456-11e7-9c3c-1de19254f912.png)

Navigating to other questions works well:
![navigate](https://cloud.githubusercontent.com/assets/5546251/25157509/ba743df8-2456-11e7-8a88-1e4045d4f8e2.png)


