### PR TITLE
Fix error message that shows up when running Karma tests.

### DIFF
--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -52,9 +52,8 @@ tie.factory('FeedbackGeneratorService', [
         }
         return '{' + humanReadableKeyValuePairs.join(', ') + '}';
       } else {
-        console.error(
+        throw Error(
           'Could not make the following object human-readable: ', jsVariable);
-        return '[UNKNOWN OBJECT]';
       }
     };
 

--- a/client/services/FeedbackGeneratorServiceSpec.js
+++ b/client/services/FeedbackGeneratorServiceSpec.js
@@ -89,16 +89,17 @@ describe('FeedbackGeneratorService', function() {
   });
 
   describe('_jsToHumanReadableUnknownObject', function() {
-    it('should return [UNKNOWN OBJECT] if provided input cannot be converted',
+    it('should throw an error if the provided input cannot be converted',
       function() {
         // Define and call blankFunction to pass lint test add 100% coverage
         var blankFunction = function() {
           return null;
         };
         blankFunction();
-        expect(
-          FeedbackGeneratorService._jsToHumanReadable(blankFunction)
-        ).toEqual('[UNKNOWN OBJECT]');
+        expect(function() {
+          FeedbackGeneratorService._jsToHumanReadable(blankFunction);
+        }).toThrowError(
+          'Could not make the following object human-readable: ');
       }
     );
   });


### PR DESCRIPTION
Currently, when Karma tests are run, a console.error() message shows up midway along the following lines:

```
    'Could not make the following object human-readable: ', function () { ... }
```

This PR fixes that. It used to be the case that we didn't convert all objects to JS, so that's why we had the console.error() before. But now that our conversion process is pretty comprehensive, I've turned the `console.error` into an actual `throw Error()` since we no longer expect it to happen in practice.