### PR TITLE
Make code font and padding a bit smaller in the feedback section.

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -265,7 +265,8 @@ tie.directive('learnerView', [function() {
           background: #333;
           color: #eee;
           font-family: monospace;
-          padding: 10px;
+          font-size: 12px;
+          padding: 2px 10px;
           width: 95%;
         }
         .tie-feedback, .tie-feedback-syntax-error {


### PR DESCRIPTION
The aim of this PR is to reduce the height of the code font a bit, in order to make the feedback easier to read and use the space more efficiently. Would welcome feedback on the direction; I'm happy to withdraw this if it's not desired.

Existing UI:

![old_version](https://cloud.githubusercontent.com/assets/10575562/25831427/de30b5f6-3418-11e7-8c79-724e6d01a6a4.png)

New UI (introduced with this PR):

![new_version](https://cloud.githubusercontent.com/assets/10575562/25831431/e6f2816a-3418-11e7-98f8-a58501ad422d.png)
