### PR TITLE
Rename getCode to getPreprocessedCode in the CodeEvalResult object.

### DIFF
--- a/client/domain/CodeEvalResultObjectFactory.js
+++ b/client/domain/CodeEvalResultObjectFactory.js
@@ -20,9 +20,10 @@
 tie.factory('CodeEvalResultObjectFactory', [
   function() {
     var CodeEvalResult = function(
-        code, output, correctnessTestResults, buggyOutputTestResults,
-        performanceTestResults, errorTraceback, errorInput) {
-      this._code = code;
+        preprocessedCode, output, correctnessTestResults,
+        buggyOutputTestResults, performanceTestResults, errorTraceback,
+        errorInput) {
+      this._preprocessedCode = preprocessedCode;
       this._output = output;
       // Several lists of test results.
       this._correctnessTestResults = correctnessTestResults;
@@ -34,8 +35,8 @@ tie.factory('CodeEvalResultObjectFactory', [
     };
 
     // Instance methods.
-    CodeEvalResult.prototype.getCode = function() {
-      return this._code;
+    CodeEvalResult.prototype.getPreprocessedCode = function() {
+      return this._preprocessedCode;
     };
 
     CodeEvalResult.prototype.getOutput = function() {
@@ -72,11 +73,13 @@ tie.factory('CodeEvalResultObjectFactory', [
 
     // Static class methods.
     CodeEvalResult.create = function(
-        code, output, correctnessTestResults, buggyOutputTestResults,
-        performanceTestResults, errorTraceback, errorInput) {
+        preprocessedCode, output, correctnessTestResults,
+        buggyOutputTestResults, performanceTestResults, errorTraceback,
+        errorInput) {
       return new CodeEvalResult(
-        code, output, correctnessTestResults, buggyOutputTestResults,
-        performanceTestResults, errorTraceback, errorInput);
+        preprocessedCode, output, correctnessTestResults,
+        buggyOutputTestResults, performanceTestResults, errorTraceback,
+        errorInput);
     };
 
     return CodeEvalResult;

--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -76,8 +76,8 @@ tie.factory('FeedbackGeneratorService', [
           if (previousMessages[0].getContent() ===
               buggyMessages[previousHintIndex]) {
             var previousCode = (
-              lastSnapshot.getCodeEvalResult().getCode());
-            if (previousCode === codeEvalResult.getCode() ||
+              lastSnapshot.getCodeEvalResult().getPreprocessedCode());
+            if (previousCode === codeEvalResult.getPreprocessedCode() ||
                 previousHintIndex === buggyMessages.length - 1) {
               hintIndex = previousHintIndex;
             } else {


### PR DESCRIPTION
This is a small change inspired by @a-zakem's note that both prerequisite checks and code eval results act on "code", but the former acts on raw code and the latter acts on preprocessed code. I'm making the name change so there's less confusion about what's what.