### PR TITLE
Make Reinforcement a sub-object of Feedback.

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -554,9 +554,7 @@ tie.directive('learnerView', [function() {
           $scope.syntaxErrorString = '';
         };
 
-        var setFeedback = function(feedbackAndReinforcement) {
-          var feedback = feedbackAndReinforcement.feedbackObject;
-          var reinforcement = feedbackAndReinforcement.reinforcement;
+        var setFeedback = function(feedback) {
           $scope.loadingIndicatorIsShown = false;
           if (feedback.isAnswerCorrect()) {
             if (question.isLastTask(currentTaskIndex)) {
@@ -590,13 +588,14 @@ tie.directive('learnerView', [function() {
               $scope.syntaxErrorString = syntaxErrorParagraph.getContent();
             } else if (syntaxErrorIndex === null) {
               $scope.syntaxErrorString = '';
-              // Updating reinforcement bullets only if no syntax errors.
-              $scope.reinforcementBullets = reinforcement.getBullets();
+              // Update reinforcement bullets only if there are no syntax
+              // errors.
+              $scope.reinforcementBullets = (
+                feedback.getReinforcement().getBullets());
             }
-            $scope.feedbackStorage.push(
-              {
-                feedbackParagraphs: feedbackParagraphs
-              });
+            $scope.feedbackStorage.push({
+              feedbackParagraphs: feedbackParagraphs
+            });
           }
 
           // Skulpt processing happens outside an Angular context, so

--- a/client/domain/FeedbackObjectFactory.js
+++ b/client/domain/FeedbackObjectFactory.js
@@ -18,7 +18,8 @@
  */
 
 tie.factory('FeedbackObjectFactory', [
-  'FeedbackParagraphObjectFactory', function(FeedbackParagraphObjectFactory) {
+  'FeedbackParagraphObjectFactory', 'ReinforcementObjectFactory',
+  function(FeedbackParagraphObjectFactory, ReinforcementObjectFactory) {
     var Feedback = function(answerIsCorrect) {
       this._paragraphs = [];
       this._answerIsCorrect = answerIsCorrect;
@@ -26,6 +27,7 @@ tie.factory('FeedbackObjectFactory', [
       // If no message was displayed, this will remain null.
       this._hintIndex = null;
       this._syntaxErrorIndex = null;
+      this._reinforcement = ReinforcementObjectFactory.create();
     };
 
     // Instance methods.
@@ -68,6 +70,14 @@ tie.factory('FeedbackObjectFactory', [
 
     Feedback.prototype.setSyntaxErrorIndex = function(index) {
       this._syntaxErrorIndex = index;
+    };
+
+    Feedback.prototype.getReinforcement = function() {
+      return this._reinforcement;
+    };
+
+    Feedback.prototype.setReinforcement = function(reinforcement) {
+      this._reinforcement = reinforcement;
     };
 
     // Static class methods.

--- a/client/domain/SnapshotObjectFactory.js
+++ b/client/domain/SnapshotObjectFactory.js
@@ -19,14 +19,12 @@
 
 tie.factory('SnapshotObjectFactory', [
   function() {
-    var Snapshot = function(
-        prereqCheckFailure, codeEvalResult, feedback, reinforcement) {
+    var Snapshot = function(prereqCheckFailure, codeEvalResult, feedback) {
       // Note that this may be null.
       this._prereqCheckFailure = prereqCheckFailure;
       this._codeEvalResult = codeEvalResult;
       this._feedback = feedback;
-      this._reinforcement = reinforcement;
-      this._timestamp = '';
+      this._timestamp = Date.now();
     };
 
     // Instance methods.
@@ -54,19 +52,9 @@ tie.factory('SnapshotObjectFactory', [
       this._feedback = feedback;
     };
 
-    Snapshot.prototype.getReinforcement = function() {
-      return this._reinforcement;
-    };
-
-    Snapshot.prototype.setReinforcement = function(reinforcement) {
-      this._reinforcement = reinforcement;
-    };
-
     // Static class methods.
-    Snapshot.create = function(
-        prereqCheckFailure, codeEvalResult, feedback, reinforcement) {
-      return new Snapshot(
-        prereqCheckFailure, codeEvalResult, feedback, reinforcement);
+    Snapshot.create = function(prereqCheckFailure, codeEvalResult, feedback) {
+      return new Snapshot(prereqCheckFailure, codeEvalResult, feedback);
     };
 
     return Snapshot;

--- a/client/services/ReinforcementGeneratorService.js
+++ b/client/services/ReinforcementGeneratorService.js
@@ -53,18 +53,17 @@ tie.factory('ReinforcementGeneratorService', [
 
     return {
       getReinforcement: function(task, codeEvalResult) {
-
         var previousSnapshot = TranscriptService.getMostRecentSnapshot();
         var previousReinforcement = null;
-        if (previousSnapshot !== null) {
-          previousReinforcement = previousSnapshot.getReinforcement();
+        if (previousSnapshot) {
+          previousReinforcement = (
+            previousSnapshot.getFeedback().getReinforcement());
         }
 
         var reinforcement = ReinforcementObjectFactory.create(task);
 
         // Copy the previous reinforcement object if we are on the same task.
-        if (previousReinforcement !== null &&
-            task === previousReinforcement.getTask()) {
+        if (previousReinforcement && task === previousReinforcement.getTask()) {
           var previousReinforcementPassedTags =
             previousReinforcement.getPassedTags();
           for (var tag in previousReinforcementPassedTags) {

--- a/client/services/TranscriptService.js
+++ b/client/services/TranscriptService.js
@@ -26,10 +26,9 @@ tie.factory('TranscriptService', [
       getTranscript: function() {
         return transcript;
       },
-      recordSnapshot: function(
-          prereqCheckFailure, codeEvalResult, feedback, reinforcement) {
+      recordSnapshot: function(prereqCheckFailure, codeEvalResult, feedback) {
         var snapshot = SnapshotObjectFactory.create(
-          prereqCheckFailure, codeEvalResult, feedback, reinforcement);
+          prereqCheckFailure, codeEvalResult, feedback);
         transcript.recordSnapshot(snapshot);
       },
       getMostRecentSnapshot: function() {

--- a/client/services/code_preprocessors/CodePreprocessorDispatcherService.js
+++ b/client/services/code_preprocessors/CodePreprocessorDispatcherService.js
@@ -21,15 +21,10 @@ tie.factory('CodePreprocessorDispatcherService', [
   'PythonCodePreprocessorService', 'LANGUAGE_PYTHON',
   function(PythonCodePreprocessorService, LANGUAGE_PYTHON) {
     return {
-      preprocess: function(
-          language, codeSubmission, auxiliaryCode, inputFunctionName,
-          mainFunctionName, outputFunctionName, correctnessTests,
-          buggyOutputTests, performanceTests) {
+      preprocess: function(language, codeSubmission, auxiliaryCode, tasks) {
         if (language === LANGUAGE_PYTHON) {
           return PythonCodePreprocessorService.preprocess(
-            codeSubmission, auxiliaryCode, inputFunctionName, mainFunctionName,
-            outputFunctionName, correctnessTests, buggyOutputTests,
-            performanceTests);
+            codeSubmission, auxiliaryCode, tasks);
         } else {
           throw Error('Language not supported: ' + language);
         }

--- a/client/services/code_preprocessors/CodePreprocessorDispatcherServiceSpec.js
+++ b/client/services/code_preprocessors/CodePreprocessorDispatcherServiceSpec.js
@@ -44,7 +44,7 @@ describe('CodePreprocessorDispatcherService', function() {
       var codeSubmission = CodeSubmissionObjectFactory.create('a = 1\nb= 2');
       var originProcessedCode = codeSubmission.getPreprocessedCode();
       CodePreprocessorDispatcherService.preprocess(
-        LANGUAGE_PYTHON, codeSubmission, '', '', '', '', [], [], []);
+        LANGUAGE_PYTHON, codeSubmission, '', []);
       expect(codeSubmission.getPreprocessedCode())
         .not.toEqual(originProcessedCode);
     });

--- a/client/services/code_preprocessors/PythonCodePreprocessorService.js
+++ b/client/services/code_preprocessors/PythonCodePreprocessorService.js
@@ -376,12 +376,26 @@ tie.factory('PythonCodePreprocessorService', [
     };
 
     return {
-      preprocess: function(
-          codeSubmission, auxiliaryCode,
-          allTasksInputFunctionNames, allTasksMainFunctionNames,
-          allTasksOutputFunctionNames,
-          allTasksCorrectnessTests, allTasksBuggyOutputTests,
-          allTasksPerformanceTests) {
+      preprocess: function(codeSubmission, auxiliaryCode, tasks) {
+        var allTasksCorrectnessTests = [];
+        var allTasksBuggyOutputTests = [];
+        var allTasksPerformanceTests = [];
+        for (var i = 0; i < tasks.length; i++) {
+          allTasksCorrectnessTests.push(tasks[i].getCorrectnessTests());
+          allTasksBuggyOutputTests.push(tasks[i].getBuggyOutputTests());
+          allTasksPerformanceTests.push(tasks[i].getPerformanceTests());
+        }
+
+        var allTasksInputFunctionNames = tasks.map(function(task) {
+          return task.getInputFunctionName();
+        });
+        var allTasksMainFunctionNames = tasks.map(function(task) {
+          return task.getMainFunctionName();
+        });
+        var allTasksOutputFunctionNames = tasks.map(function(task) {
+          return task.getOutputFunctionName();
+        });
+
         // Transform the student code (without changing the number of lines) to
         // put it within a class.
         var transformedStudentCode = this._transformCodeToInstanceMethods(


### PR DESCRIPTION
We currently have a slightly weird pattern where we pass manually-constructed dicts with "feedback" and "reinforcement" keys to the frontend. This PR cleans this up by treating Reinforcement objects as a subpart of Feedback objects (especially since they're all now shown in the same pane in the UI anyway).