### PR TITLE
Fix #309: Do not compute reinforcements when there is a runtime error.

### DIFF
--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -240,7 +240,7 @@ tie.factory('FeedbackGeneratorService', [
       getFeedback: function(tasks, codeEvalResult, rawCodeLineIndexes) {
         var feedback = _getFeedbackWithoutReinforcement(
           tasks, codeEvalResult, rawCodeLineIndexes);
-        if (tasks.length > 0) {
+        if (tasks.length > 0 && !codeEvalResult.getErrorString()) {
           feedback.setReinforcement(
             ReinforcementGeneratorService.getReinforcement(
               tasks[tasks.length - 1], codeEvalResult));


### PR DESCRIPTION
I introduced this bug in the #304 refactor, sorry. /cc @eyurko 