### PR TITLE
Add Print Feedback Directive

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -66,6 +66,9 @@ tie.directive('learnerView', [function() {
                     <p ng-if="set.feedbackParagraphs" ng-repeat="paragraph in set.feedbackParagraphs"
                         class="tie-feedback-paragraph"
                         ng-class="{'tie-feedback-paragraph-code': paragraph.isCodeParagraph()}">
+                      <span ng-if="paragraph.isPrintFeedback()">
+                        <print-feedback-snippet logOutput="paragraph.getContent()"></print-feedback-snippet>
+                      </span>
                       <span ng-if="paragraph.isTextParagraph()">
                         {{paragraph.getContent()}}
                       </span>

--- a/client/components/PrintFeedbackSnippetDirective.js
+++ b/client/components/PrintFeedbackSnippetDirective.js
@@ -1,0 +1,79 @@
+// Copyright 2017 The TIE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Directive for showing feedback when user has print statements
+ * in their code submission.
+ */
+
+tie.directive('printFeedbackSnippet', [function() {
+  return {
+    restrict: 'E',
+    scope: {
+      getLogOutput: '&content'
+    },
+    template:`
+      <p class="tie-feedback-paragraph">
+        We noticed that you used a print statement in your latest code submission.
+        This is a gentle reminder that while this is a valid debugging method,
+        you do not have this resource available to you during interviews.
+      </p>
+      <p class="tie-feedback-paragraph">
+        If you would still like to view the output from your print statements,
+        then press the toggle below.
+      </p>
+      <button class="tie-feedback-toggle" ng-click="onToggleClick" ng-class="{'active': outputIsShown}">Log Output</button>
+      <div class="tie-code-panel" ng-show="outputIsShown">
+        <p class="tie-feedback-paragraph tie-feedback-paragraph-code">
+          {{logOutput}}
+        </p>
+      </div>
+      <style>
+        .tie-feedback-toggle {
+          background-color: #eee;
+          color: #444;
+          cursor: pointer;
+          padding: 18px;
+          width: 100%;
+          text-align: left;
+          border: none;
+          outline: none;
+          transition: 0.4s;
+        }
+        .tie-feedback-toggle:hover, .tie-feedback-toggle.active {
+          background-color: #ddd;
+        }
+        .tie-code-panel {
+          padding: 5px;
+          background-color: #333;
+        }
+      </style>
+    `,
+    controller: [
+      '$scope', function($scope) {
+        $scope.logOutput = [];
+        $scope.outputIsShown = false;
+
+        $scope.onToggleClick = function() {
+          $scope.outputIsShown = !($scope.outputIsShown);
+        };
+
+        $scope.$watch($scope.getLogOutput, function(newValue) {
+          var htmlFormattedContent = newValue.replace(/ /g, '\u00A0');
+          $scope.logOutput = htmlFormattedContent;
+        });
+      }
+    ]
+  };
+}]);

--- a/client/components/PrintFeedbackSnippetDirective.js
+++ b/client/components/PrintFeedbackSnippetDirective.js
@@ -42,21 +42,21 @@ tie.directive('printFeedbackSnippet', [function() {
       <style>
         .tie-feedback-toggle {
           background-color: #eee;
+          border: none;
           color: #444;
           cursor: pointer;
+          outline: none;
           padding: 18px;
           width: 100%;
           text-align: left;
-          border: none;
-          outline: none;
           transition: 0.4s;
         }
         .tie-feedback-toggle:hover, .tie-feedback-toggle.active {
           background-color: #ddd;
         }
         .tie-code-panel {
-          padding: 5px;
           background-color: #333;
+          padding: 5px;
         }
       </style>
     `,

--- a/client/components/PrintFeedbackSnippetDirective.js
+++ b/client/components/PrintFeedbackSnippetDirective.js
@@ -21,7 +21,7 @@ tie.directive('printFeedbackSnippet', [function() {
   return {
     restrict: 'E',
     scope: {
-      getLogOutput: '&content'
+      getLogOutput: '&logOutput'
     },
     template: `
       <p class="tie-feedback-paragraph">

--- a/client/components/PrintFeedbackSnippetDirective.js
+++ b/client/components/PrintFeedbackSnippetDirective.js
@@ -23,7 +23,7 @@ tie.directive('printFeedbackSnippet', [function() {
     scope: {
       getLogOutput: '&content'
     },
-    template:`
+    template: `
       <p class="tie-feedback-paragraph">
         We noticed that you used a print statement in your latest code submission.
         This is a gentle reminder that while this is a valid debugging method,

--- a/client/domain/FeedbackParagraphObjectFactory.js
+++ b/client/domain/FeedbackParagraphObjectFactory.js
@@ -47,6 +47,13 @@ tie.factory('FeedbackParagraphObjectFactory', [
     var PARAGRAPH_TYPE_SYNTAX_ERROR = 'error';
 
     /**
+     * Indicates print feedback error type of Feedback paragraph.
+     * @const
+     * @type {string}
+     */
+    var PARAGRAPH_TYPE_PRINT_FEEDBACK = 'printFeedback';
+
+    /**
      * Constructor for FeedbackParagraph
      *
      * @param {string} type Indicates what type of Feedback Paragraph this
@@ -101,6 +108,14 @@ tie.factory('FeedbackParagraphObjectFactory', [
     };
 
     /**
+     * Checks if the Paragraph has the output for the user's print statements.
+     * @returns {boolean}
+     */
+    FeedbackParagraph.prototype.isPrintFeedback = function() {
+      return this._type === PARAGRAPH_TYPE_PRINT_FEEDBACK;
+    };
+
+    /**
      * A getter for the _content property.
      *
      * @returns {string}
@@ -138,6 +153,19 @@ tie.factory('FeedbackParagraphObjectFactory', [
      */
     FeedbackParagraph.createSyntaxErrorParagraph = function(error) {
       return new FeedbackParagraph(PARAGRAPH_TYPE_SYNTAX_ERROR, error);
+    };
+
+    /**
+     * Returns a FeedbackParagraph with the output for feedback when a user
+     * has print statements in their code submission.
+     *
+     * @param {string} consoleOutput Logs in the console due to user's print
+     *    statements
+     * @returns {FeedbackParagraph}
+     */
+    FeedbackParagraph.createPrintFeedbackParagraph = function(consoleOutput) {
+      return new FeedbackParagraph(
+          PARAGRAPH_TYPE_PRINT_FEEDBACK, consoleOutput);
     };
 
     return FeedbackParagraph;


### PR DESCRIPTION
* Created the `PrintFeedbackDirective` to display the log output toggle and related warning whenever a user submits code that has a `print` statement in it.
* Added `isPrintFeedback` and `createPrintFeedbackParagraph` to `FeedbackParagraph`
* Added related lines to Learner View to allow for display of Print feedback paragraphs before all other feedback paragraphs for a given submission

Example of what feedback would look like with the log output expanded: 
![image](https://user-images.githubusercontent.com/12034267/27493730-b2002dbc-57ff-11e7-8415-f9301987df7f.png)

Example of feedback with log output not expanded:
![image](https://user-images.githubusercontent.com/12034267/27493769-e3945e98-57ff-11e7-9574-daea35e00434.png)

