### PR TITLE
Fix #350: Save Feedback State to localStorage

### DIFF
--- a/client/app.html
+++ b/client/app.html
@@ -52,6 +52,7 @@
     <script src="domain/TranscriptObjectFactory.js"></script>
     <script src="services/CodeStorageService.js"></script>
     <script src="services/FeedbackGeneratorService.js"></script>
+    <script src="services/FeedbackStorageService.js"></script>
     <script src="services/QuestionDataService.js"></script>
     <script src="services/SolutionHandlerService.js"></script>
     <script src="services/TranscriptService.js"></script>

--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -103,6 +103,7 @@ tie.directive('learnerView', [function() {
                       ng-options="i.themeName as i.themeName for i in themes">
                 <option style="display: none" value="">Theme</option>
               </select>
+              <button class="tie-button" ng-click="resetFeedback()">Clear Feedback</button>
             </div>
             <div class="tie-coding-ui">
               <div class="tie-lang-terminal">
@@ -192,6 +193,7 @@ tie.directive('learnerView', [function() {
           font-family: Roboto, 'Helvetica Neue', 'Lucida Grande', sans-serif;
           font-size: 12px;
           height: 24px;
+          margin-top: 10px;
           padding: 1px 6px;
           width: 100px;
         }
@@ -217,7 +219,6 @@ tie.directive('learnerView', [function() {
         }
         .tie-code-reset {
           float: left;
-          margin-top: 10px;
         }
         .tie-coding-terminal .CodeMirror {
           /* Overwriting codemirror defaults */
@@ -464,7 +465,6 @@ tie.directive('learnerView', [function() {
         }
         .tie-run-button {
           float: right;
-          margin-top: 10px;
           position: relative;
         }
         .tie-run-button:hover {
@@ -815,6 +815,16 @@ tie.directive('learnerView', [function() {
           // $scope.$apply() is needed to force a DOM update.
           $scope.$apply();
           $scope.scrollToBottomOfFeedbackWindow();
+        };
+
+        /**
+         * Resets the feedback window and clears the local storage of the
+         * feedback for the given question.
+         */
+        $scope.resetFeedback = function() {
+          FeedbackStorageService.clearLocalStorageFeedback(
+            $scope.questionIds[$scope.currentQuestionIndex], language);
+          clearFeedback();
         };
 
         /**

--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -751,7 +751,7 @@ tie.directive('learnerView', [function() {
           var storedFeedbackParagraphs =
             FeedbackStorageService.loadStoredFeedback(questionId, language);
           if (storedFeedbackParagraphs !== null) {
-            for (var i = 0; i < storedFeedbackParagraphs.length; i ++) {
+            for (var i = 0; i < storedFeedbackParagraphs.length; i++) {
               $scope.feedbackStorage.push({
                 feedbackParagraphs: storedFeedbackParagraphs[i]
               });
@@ -809,6 +809,9 @@ tie.directive('learnerView', [function() {
             $scope.feedbackStorage.push({
               feedbackParagraphs: feedbackParagraphs
             });
+            FeedbackStorageService.storeFeedback(
+              $scope.questionIds[$scope.currentQuestionIndex],
+              $scope.feedbackStorage, language);
           }
 
           // Skulpt processing happens outside an Angular context, so
@@ -1028,7 +1031,7 @@ tie.directive('learnerView', [function() {
 
           if (!$scope.autosaveOn) {
             $scope.autosaveOn = true;
-            autosaveCancelPromise = $interval(function () {
+            autosaveCancelPromise = $interval(function() {
               var currentQuestionId =
                   $scope.questionIds[$scope.currentQuestionIndex];
               if (angular.equals(cachedCode, $scope.editorContents.code)) {

--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -1033,7 +1033,7 @@ tie.directive('learnerView', [function() {
             $scope.autosaveOn = true;
             autosaveCancelPromise = $interval(function() {
               var currentQuestionId =
-                  $scope.questionIds[$scope.currentQuestionIndex];
+                $scope.questionIds[$scope.currentQuestionIndex];
               if (angular.equals(cachedCode, $scope.editorContents.code)) {
                 // No code change, stop autosave loop.
                 stopAutosave();

--- a/client/components/LearnerViewDirectiveSpec.js
+++ b/client/components/LearnerViewDirectiveSpec.js
@@ -86,6 +86,42 @@ describe('LearnerViewDirective', function() {
     });
   });
 
+  describe('resetFeedback', function() {
+    var FeedbackParagraphObjectFactory;
+    var FeedbackStorageService;
+
+    beforeEach(inject(function(_FeedbackParagraphObjectFactory_,
+      _FeedbackStorageService_) {
+      FeedbackParagraphObjectFactory = _FeedbackParagraphObjectFactory_;
+      FeedbackStorageService = _FeedbackStorageService_;
+    }));
+
+    it('should reset the feedback state', function() {
+      $scope.questionIds.forEach(function(questionId, index) {
+        $scope.currentQuestionIndex = index;
+        var sampleFeedbackParagraph =
+          FeedbackParagraphObjectFactory.createTextParagraph("test");
+        $scope.feedbackStorage.push({
+          feedbackParagraphs: [sampleFeedbackParagraph]
+        });
+        FeedbackStorageService.storeFeedback(questionId, $scope.feedbackStorage,
+          LANGUAGE);
+        var storedFeedback = FeedbackStorageService.loadStoredFeedback(
+          questionId, LANGUAGE);
+        expect(storedFeedback[0][0].isTextParagraph()).toBe(true);
+        expect(storedFeedback[0][0].getContent()).toEqual('test');
+
+        expect($scope.feedbackStorage.length).toEqual(1);
+
+        $scope.resetFeedback();
+
+        expect(FeedbackStorageService.loadStoredFeedback(questionId, LANGUAGE))
+            .toBeNull();
+        expect($scope.feedbackStorage.length).toEqual(0);
+      });
+    });
+  });
+
   describe("autosave", function() {
     var $interval;
     var $timeout;

--- a/client/services/FeedbackStorageService.js
+++ b/client/services/FeedbackStorageService.js
@@ -1,0 +1,136 @@
+// Copyright 2017 The TIE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview A service that saves the feedback paragraphs to the browser's
+ *    localStorage.
+ */
+
+tie.factory('FeedbackStorageService', [
+  'FeedbackParagraphObjectFactory',
+  function(FeedbackParagraphObjectFactory) {
+    // In some browsers, localStorage is not available and its invocation throws
+    // an error.
+    var localStorageIsAvailable = false;
+    try {
+      localStorageIsAvailable = Boolean(localStorage);
+    } catch (e) {
+      localStorageIsAvailable = false;
+    }
+
+    /**
+     * Returns the local storage key for a given question.
+     *
+     * @param {string} questionId
+     * @param {string} language
+     * @returns {string}
+     */
+    var getLocalStorageKey = function(questionId, language) {
+      return questionId + "-feedback:" + language;
+    };
+
+    return {
+      /**
+       * Checks if the local storage is available.
+       *
+       * @returns {boolean}
+       */
+      isAvailable: function() {
+        return localStorageIsAvailable;
+      },
+
+      /**
+       * Stores the feedback into local storage - so long as local storage is
+       * available.
+       *
+       * @param {string} questionId
+       * @param {[{feedbackParagraphs: FeedbackParagraph}]} cachedFeedback
+       * @param {string} language
+       */
+      storeFeedback: function(questionId, cachedFeedback, language) {
+        console.log('feedback stored');
+        if (!localStorageIsAvailable) {
+          return;
+        }
+
+        var localStorageKey = getLocalStorageKey(questionId, language);
+        var feedbackParagraphs = [];
+        for (var i = 0; i < cachedFeedback.length; i ++) {
+          feedbackParagraphs.push(cachedFeedback[i].feedbackParagraphs);
+        }
+        localStorage.setItem(
+          localStorageKey, JSON.stringify(feedbackParagraphs));
+      },
+
+      /**
+       * Loads feedback state from local storage if local storage is available.
+       * If local storage is not available, then it returns null.
+       *
+       * @param {string} questionId
+       * @param {string} language
+       * @returns {[FeedbackParagraph]|null)
+       */
+      loadStoredFeedback: function(questionId, language) {
+        if (!localStorageIsAvailable) {
+          return null;
+        }
+
+        var localStorageKey = getLocalStorageKey(questionId, language);
+        var storedFeedback = localStorage.getItem(localStorageKey);
+        if (storedFeedback) {
+          var unparsedParagraphs = JSON.parse(storedFeedback);
+          var parsedParagraphs = [];
+          for (var i = 0; i < unparsedParagraphs.length; i ++) {
+            var paragraphSet = [];
+            for (var j = 0; j < unparsedParagraphs[i].length; j++) {
+              var paragraph;
+              if (unparsedParagraphs[i][j]._type === 'error') {
+                paragraph =
+                    FeedbackParagraphObjectFactory.createSyntaxErrorParagraph(
+                        unparsedParagraphs[i][j]._content);
+              } else if (unparsedParagraphs[i][j]._type === 'code') {
+                paragraph = FeedbackParagraphObjectFactory.createCodeParagraph(
+                    unparsedParagraphs[i][j]._content);
+              } else {
+                paragraph = FeedbackParagraphObjectFactory.createTextParagraph(
+                    unparsedParagraphs[i][j]._content);
+              }
+              paragraphSet.push(paragraph);
+            }
+            parsedParagraphs.push(paragraphSet);
+          }
+          return parsedParagraphs;
+        } else {
+          return null;
+        }
+      },
+
+      /**
+       * Clears the local storage such that there is no longer any feedback
+       * stored there.
+       *
+       * @param {string} questionId
+       * @param {string} language
+       */
+      clearLocalStorageFeedback: function(questionId, language) {
+        if (!localStorageIsAvailable) {
+          return;
+        }
+
+        var localStorageKey = getLocalStorageKey(questionId, language);
+        localStorage.removeItem(localStorageKey);
+      }
+    };
+  }
+]);

--- a/client/services/FeedbackStorageService.js
+++ b/client/services/FeedbackStorageService.js
@@ -59,14 +59,13 @@ tie.factory('FeedbackStorageService', [
        * @param {string} language
        */
       storeFeedback: function(questionId, cachedFeedback, language) {
-        console.log('feedback stored');
         if (!localStorageIsAvailable) {
           return;
         }
 
         var localStorageKey = getLocalStorageKey(questionId, language);
         var feedbackParagraphs = [];
-        for (var i = 0; i < cachedFeedback.length; i ++) {
+        for (var i = 0; i < cachedFeedback.length; i++) {
           feedbackParagraphs.push(cachedFeedback[i].feedbackParagraphs);
         }
         localStorage.setItem(
@@ -91,7 +90,7 @@ tie.factory('FeedbackStorageService', [
         if (storedFeedback) {
           var unparsedParagraphs = JSON.parse(storedFeedback);
           var parsedParagraphs = [];
-          for (var i = 0; i < unparsedParagraphs.length; i ++) {
+          for (var i = 0; i < unparsedParagraphs.length; i++) {
             var paragraphSet = [];
             for (var j = 0; j < unparsedParagraphs[i].length; j++) {
               var paragraph;

--- a/client/services/FeedbackStorageServiceSpec.js
+++ b/client/services/FeedbackStorageServiceSpec.js
@@ -1,0 +1,145 @@
+// Copyright 2017 The TIE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for FeedbackStorageService.
+ * Please be aware, the hash key format is {{questionId}}-feedback:{{language}}
+ */
+
+describe('FeedbackStorageService', function() {
+  var LANGUAGE = 'python';
+  var FAILED_LANGUAGE = 'java';
+  var NUM_CHARS_QUESTION_ID = 10;
+  var NUM_QUESTIONS = 5;
+
+  var FeedbackStorageService;
+  var FeedbackParagraphObjectFactory;
+
+  var generateRandomChars = function(number) {
+    var generatedChars = '';
+    var possible = (
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789');
+
+    for (var i = 0; i < number; i++) {
+      generatedChars += possible.charAt(
+        Math.floor(Math.random() * possible.length));
+    }
+    return generatedChars;
+  };
+
+  var sampleQuestionIds = [];
+  var sampleFeedback;
+  var sampleFeedbackStorage;
+
+  var sampleFeedbackJson =
+    '[[{"_type":"error","_content":"SyntaxError: test"}]]';
+
+  beforeEach(module('tie'));
+  beforeEach(inject(function($injector) {
+    localStorage.clear();
+    FeedbackStorageService = $injector.get('FeedbackStorageService');
+    FeedbackParagraphObjectFactory = $injector.get(
+      'FeedbackParagraphObjectFactory');
+
+    sampleFeedback = FeedbackParagraphObjectFactory.createSyntaxErrorParagraph(
+      'SyntaxError: test');
+    sampleFeedbackStorage = [{
+      feedbackParagraphs: [sampleFeedback]
+    }];
+
+    for (var i = 0; i < NUM_QUESTIONS; i++) {
+      // Generate random question Id with
+      // length of NUM_CHARS_QUESTION_ID
+      sampleQuestionIds[i] = generateRandomChars(
+        Math.floor(Math.random() * NUM_CHARS_QUESTION_ID));
+    }
+  }));
+
+  afterEach(function() {
+    localStorage.clear();
+  });
+
+  describe('storeFeedback', function() {
+    it('should store feedback paragraphs to browser', function() {
+      expect(localStorage.length).toEqual(0);
+      sampleQuestionIds.forEach(function(questionId) {
+        FeedbackStorageService.storeFeedback(questionId, sampleFeedbackStorage,
+          LANGUAGE);
+        var key = questionId + "-feedback:" + LANGUAGE;
+        expect(localStorage.getItem(key)).toEqual(sampleFeedbackJson);
+      });
+    });
+  });
+
+  describe('loadStoredFeedback', function() {
+    it('should retrieve stored feedback from browser', function() {
+      expect(localStorage.length).toEqual(0);
+      sampleQuestionIds.forEach(function(questionId) {
+        var key = questionId + "-feedback:" + LANGUAGE;
+        localStorage.setItem(key, sampleFeedbackJson);
+        var loadedFeedback = FeedbackStorageService.loadStoredFeedback(
+          questionId, LANGUAGE);
+        expect(loadedFeedback[0][0].isSyntaxErrorParagraph()).toBe(true);
+        expect(loadedFeedback[0][0].getContent()).toEqual('SyntaxError: test');
+      });
+    });
+
+    it('should fail to retrieve feedback and return null if there is no ' +
+        'feedback stored', function() {
+      expect(localStorage.length).toEqual(0);
+      sampleQuestionIds.forEach(function(questionId) {
+        expect(FeedbackStorageService.loadStoredFeedback(questionId,
+          FAILED_LANGUAGE)).toEqual(null);
+      });
+    });
+  });
+
+  describe('storeAndLoadFeedback', function() {
+    it('should store and load stored feedback from browser', function() {
+      expect(localStorage.length).toEqual(0);
+      sampleQuestionIds.forEach(function(questionId) {
+        FeedbackStorageService.storeFeedback(
+          questionId, sampleFeedbackStorage, LANGUAGE);
+        var loadedFeedback = FeedbackStorageService.loadStoredFeedback(
+          questionId, LANGUAGE);
+        expect(loadedFeedback[0][0].isSyntaxErrorParagraph()).toBe(true);
+        expect(loadedFeedback[0][0].getContent()).toEqual('SyntaxError: test');
+      });
+    });
+  });
+
+  describe('verifyLocalStorageKey', function() {
+    it('should verify composed keys match localStorage keys', function() {
+      expect(localStorage.length).toEqual(0);
+      sampleQuestionIds.forEach(function(questionId) {
+        FeedbackStorageService.storeFeedback(
+          questionId, sampleFeedbackStorage, LANGUAGE);
+        var key = questionId + '-feedback:' + LANGUAGE;
+        expect(localStorage.getItem(key)).toEqual(sampleFeedbackJson);
+      });
+    });
+  });
+
+  describe('clearLocalStorageFeedback', function() {
+    it('should remove feedback from localStorage', function() {
+      sampleQuestionIds.forEach(function(questionId) {
+        var key = questionId + '-feedback:' + LANGUAGE;
+        localStorage.setItem(key, sampleFeedbackJson);
+        expect(localStorage.getItem(key)).toEqual(sampleFeedbackJson);
+        FeedbackStorageService.clearLocalStorageFeedback(questionId, LANGUAGE);
+        expect(localStorage.getItem(key)).toEqual(null);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fix to Issue #350 

* Created `FeedbackStorageService` to store and retrieve feedback state (i.e. Feedback Paragraphs) from the browser's local storage so feedback state is maintained across reloads and switching between questions
* Added a `Clear Feedback` button in the UI to allow user to clear Feedback state
* Added relevant tests to `FeedbackStorageServiceSpec` and to `LearnerViewDirective`
* Changed `.tie-button` class to all have `margin-top: 10px` as that seemed to be consistent styling for all button controls and could thus be applied to future button controls as well


