### PR TITLE
Fix #36: Prevent Invalid System/AuxiliaryCode Calls

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -122,6 +122,20 @@ tie.constant('SYSTEM_CODE', {
   ].join('\n')
 });
 
+/**
+ * Provides class names for system and auxiliary code according to the language
+ * that is being used.
+ *
+ * @type {{}}
+ * @constant
+ */
+tie.constant('SYSTEM_AUXILIARY_CLASSES', {
+  python: {
+    systemClass: 'System',
+    auxiliaryClass: 'AuxiliaryCode'
+  }
+});
+
 // Pre-requisite check error types
 /**
  * Pre-requisite check error type for when starter code is missing or altered.

--- a/client/app.js
+++ b/client/app.js
@@ -124,20 +124,6 @@ tie.constant('SYSTEM_CODE', {
   ].join('\n')
 });
 
-/**
- * Provides class names for system and auxiliary code according to the language
- * that is being used.
- *
- * @type {{}}
- * @constant
- */
-tie.constant('SYSTEM_AUXILIARY_CLASSES', {
-  python: {
-    systemClass: 'System',
-    auxiliaryClass: 'AuxiliaryCode'
-  }
-});
-
 // Pre-requisite check error types
 /**
  * Pre-requisite check error type for when starter code is missing or altered.

--- a/client/app.js
+++ b/client/app.js
@@ -148,6 +148,25 @@ tie.constant('PREREQ_CHECK_TYPE_BAD_IMPORT', 'badImport');
 tie.constant('PREREQ_CHECK_TYPE_GLOBAL_CODE', 'globalCode');
 
 /**
+ * Pre-requisite check error type to see if the user tried to use any methods
+ * from System in their code submission.
+ *
+ * @type {string}
+ * @constant
+ */
+tie.constant('PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL', 'invalidSystem');
+
+/**
+ * Pre-requisite check error type to see if the user tried to use an
+ * AuxiliaryCode method in their code submission.
+ *
+ * @type {string}
+ * @constant
+ */
+tie.constant(
+  'PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL', 'invalidAuxiliaryCode');
+
+/**
  * Name of the list in which correctness test results are stored.
  *
  * @type {string}

--- a/client/domain/PrereqCheckFailureObjectFactory.js
+++ b/client/domain/PrereqCheckFailureObjectFactory.js
@@ -19,10 +19,12 @@
 
 tie.factory('PrereqCheckFailureObjectFactory', [
   'PREREQ_CHECK_TYPE_BAD_IMPORT', 'PREREQ_CHECK_TYPE_MISSING_STARTER_CODE',
-  'PREREQ_CHECK_TYPE_GLOBAL_CODE',
+  'PREREQ_CHECK_TYPE_GLOBAL_CODE', 'PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL',
+  'PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL',
   function(
       PREREQ_CHECK_TYPE_BAD_IMPORT, PREREQ_CHECK_TYPE_MISSING_STARTER_CODE,
-      PREREQ_CHECK_TYPE_GLOBAL_CODE) {
+      PREREQ_CHECK_TYPE_GLOBAL_CODE, PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL,
+      PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL) {
     /**
      * PrereqCheckFailure encapsulates all of the data necessary to represent
      * one prerequisite check failure that a student's code submission can
@@ -87,6 +89,27 @@ tie.factory('PrereqCheckFailureObjectFactory', [
      */
     PrereqCheckFailure.prototype.setType = function(type) {
       this._type = type;
+    };
+    /**
+     * Checks to see if the error is due to the user trying to utilize the
+     * System class/method in their submission.
+     *
+     * @returns {boolean} Indicates if this failure is of type "invalid system
+     * call"
+     */
+    PrereqCheckFailure.prototype.hasInvalidSystemCall = function() {
+      return (this._type === PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL);
+    };
+
+    /**
+     * Checks to see if the error is due to the user trying to utilize the
+     * AuxiliaryCode class/method in their submission.
+     *
+     * @returns {boolean} Indicates if this failure is of type "invalid
+     * auxiliarycode call"
+     */
+    PrereqCheckFailure.prototype.hasInvalidAuxiliaryCodeCall = function() {
+      return (this._type === PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL);
     };
 
     /**

--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -22,10 +22,12 @@ tie.factory('FeedbackGeneratorService', [
   'FeedbackObjectFactory', 'TranscriptService', 'ReinforcementGeneratorService',
   'CODE_EXECUTION_TIMEOUT_SECONDS', 'SUPPORTED_PYTHON_LIBS',
   'RUNTIME_ERROR_FEEDBACK_MESSAGES', 'LANGUAGE_PYTHON',
+  'CLASS_NAME_AUXILIARY_CODE', 'CLASS_NAME_SYSTEM_CODE',
   function(
       FeedbackObjectFactory, TranscriptService, ReinforcementGeneratorService,
       CODE_EXECUTION_TIMEOUT_SECONDS, SUPPORTED_PYTHON_LIBS,
-      RUNTIME_ERROR_FEEDBACK_MESSAGES, LANGUAGE_PYTHON) {
+      RUNTIME_ERROR_FEEDBACK_MESSAGES, LANGUAGE_PYTHON,
+      CLASS_NAME_AUXILIARY_CODE, CLASS_NAME_SYSTEM_CODE) {
     // TODO(sll): Update this function to take the programming language into
     // account when generating the human-readable representations. Currently,
     // it assumes that Python is being used.
@@ -420,8 +422,8 @@ tie.factory('FeedbackGeneratorService', [
           ].join(''));
           feedback.appendCodeParagraph([
             'ForbiddenNamespaceError: It looks like you\'re trying to call ',
-            'the AuxiliaryCode class or its methods, which is forbidden. ',
-            'Please resubmit without using this class.'
+            'the ' + CLASS_NAME_AUXILIARY_CODE + ' class or its methods, ',
+            'which is forbidden. Please resubmit without using this class.'
           ].join(''));
         } else if (prereqCheckFailure.hasInvalidSystemCall()) {
           feedback.appendTextParagraph([
@@ -429,9 +431,9 @@ tie.factory('FeedbackGeneratorService', [
             'message: '
           ].join(''));
           feedback.appendCodeParagraph([
-            'ForbiddenNamespaceError: It looks you\'re using the System class ',
-            'or its methods, which is forbidden. Please resubmit without ',
-            'using this class.'
+            'ForbiddenNamespaceError: It looks you\'re using the ' +
+            CLASS_NAME_SYSTEM_CODE + ' class or its methods, which is ',
+            'forbidden. Please resubmit without using this class.'
           ].join(''));
         } else {
           // Prereq check failure type not handled; throw an error

--- a/client/services/FeedbackGeneratorService.js
+++ b/client/services/FeedbackGeneratorService.js
@@ -382,6 +382,26 @@ tie.factory('FeedbackGeneratorService', [
             'Please keep your code within the existing predefined functions',
             '-- we cannot process code in the global scope.'
           ].join(' '));
+        } else if (prereqCheckFailure.hasInvalidAuxiliaryCodeCall()) {
+          feedback.appendTextParagraph([
+            'Looks like your code had a runtime error. Here is the error ',
+            'message: '
+          ].join(''));
+          feedback.appendCodeParagraph([
+            'ForbiddenNamespaceError: It looks like you\'re trying to call ',
+            'the AuxiliaryCode class or its methods, which is forbidden. ',
+            'Please resubmit without using this class.'
+          ].join(''));
+        } else if (prereqCheckFailure.hasInvalidSystemCall()) {
+          feedback.appendTextParagraph([
+            'Looks like your code had a runtime error. Here is the error ',
+            'message: '
+          ].join(''));
+          feedback.appendCodeParagraph([
+            'ForbiddenNamespaceError: It looks you\'re using the System class ',
+            'or its methods, which is forbidden. Please resubmit without ',
+            'using this class.'
+          ].join(''));
         } else {
           // Prereq check failure type not handled; throw an error
           throw new Error(['Unrecognized prereq check failure type ',

--- a/client/services/FeedbackGeneratorServiceSpec.js
+++ b/client/services/FeedbackGeneratorServiceSpec.js
@@ -34,6 +34,8 @@ describe('FeedbackGeneratorService', function() {
   var PREREQ_CHECK_TYPE_MISSING_STARTER_CODE;
   var PREREQ_CHECK_TYPE_BAD_IMPORT;
   var PREREQ_CHECK_TYPE_GLOBAL_CODE;
+  var PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL;
+  var PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL;
 
   beforeEach(module('tie'));
   beforeEach(inject(function($injector) {
@@ -58,6 +60,10 @@ describe('FeedbackGeneratorService', function() {
       'PREREQ_CHECK_TYPE_MISSING_STARTER_CODE');
     PREREQ_CHECK_TYPE_GLOBAL_CODE = $injector.get(
       'PREREQ_CHECK_TYPE_GLOBAL_CODE');
+    PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL = $injector.get(
+      'PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL');
+    PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL = $injector.get(
+      'PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL');
 
     var taskDict = [{
       instructions: [''],
@@ -631,6 +637,50 @@ describe('FeedbackGeneratorService', function() {
         ].join(' '));
         expect(paragraphs[0].isTextParagraph()).toBe(true);
       });
+
+    it('should return the correct info if it has an invalid AuxiliaryCode call',
+      function() {
+        var prereqFailure = PrereqCheckFailureObjectFactory.create(
+          PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL, null, null);
+        var feedback = FeedbackGeneratorService.getPrereqFailureFeedback(
+          prereqFailure);
+        expect(feedback.isAnswerCorrect()).toEqual(false);
+        var paragraphs = feedback.getParagraphs();
+        expect(paragraphs[0].getContent()).toEqual([
+          'Looks like your code had a runtime error. Here is the error',
+          'message: '
+        ].join(' '));
+        expect(paragraphs[0].isTextParagraph()).toBe(true);
+        expect(paragraphs[1].getContent()).toEqual([
+          'ForbiddenNamespaceError: It looks like you\'re trying to call ',
+          'the AuxiliaryCode class or its methods, which is forbidden. ',
+          'Please resubmit without using this class.'
+        ].join(''));
+        expect(paragraphs[1].isCodeParagraph()).toBe(true);
+      }
+    );
+
+    it('should return the correct info if it has an invalid System call',
+      function() {
+        var prereqFailure = PrereqCheckFailureObjectFactory.create(
+            PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL, null, null);
+        var feedback = FeedbackGeneratorService.getPrereqFailureFeedback(
+            prereqFailure);
+        expect(feedback.isAnswerCorrect()).toEqual(false);
+        var paragraphs = feedback.getParagraphs();
+        expect(paragraphs[0].getContent()).toEqual([
+          'Looks like your code had a runtime error. Here is the error',
+          'message: '
+        ].join(' '));
+        expect(paragraphs[0].isTextParagraph()).toBe(true);
+        expect(paragraphs[1].getContent()).toEqual([
+          'ForbiddenNamespaceError: It looks you\'re using the System class ',
+          'or its methods, which is forbidden. Please resubmit without ',
+          'using this class.'
+        ].join(''));
+        expect(paragraphs[1].isCodeParagraph()).toBe(true);
+      }
+    );
 
     it('should throw an error if using an unknown PrereqCheckFailureObject' +
       'type', function() {

--- a/client/services/code_evaluators/PythonPrereqCheckService.js
+++ b/client/services/code_evaluators/PythonPrereqCheckService.js
@@ -21,15 +21,14 @@ tie.factory('PythonPrereqCheckService', [
   'PrereqCheckFailureObjectFactory', 'PREREQ_CHECK_TYPE_BAD_IMPORT',
   'PREREQ_CHECK_TYPE_MISSING_STARTER_CODE', 'SUPPORTED_PYTHON_LIBS',
   'PREREQ_CHECK_TYPE_GLOBAL_CODE', 'PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL',
-  'PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL', 'SYSTEM_AUXILIARY_CLASSES',
+  'PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL', 'CLASS_NAME_AUXILIARY_CODE',
+  'CLASS_NAME_SYSTEM_CODE',
   function(
       PrereqCheckFailureObjectFactory, PREREQ_CHECK_TYPE_BAD_IMPORT,
       PREREQ_CHECK_TYPE_MISSING_STARTER_CODE, SUPPORTED_PYTHON_LIBS,
       PREREQ_CHECK_TYPE_GLOBAL_CODE, PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL,
-      PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL, SYSTEM_AUXILIARY_CLASSES) {
-    var AUXILIARYCODE_CALL = 'auxiliaryCode';
-    var SYSTEM_CALL = 'system';
-
+      PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL, CLASS_NAME_AUXILIARY_CODE,
+      CLASS_NAME_SYSTEM_CODE) {
     /**
      * Removes trailing white space that may be at the end of a string.
      *
@@ -148,26 +147,30 @@ tie.factory('PythonPrereqCheckService', [
     };
 
     /**
-     * Returns whether the user tries to call the System or AuxiliaryCode
-     * classes/methods. Will return the string 'system' if a System method is
-     * called, 'auxiliaryCode' if an AuxiliaryCode method is called, or null
-     * if neither classes' methods are called.
+     * Returns whether the user tries to call the System class or its methods
+     * in the given code.
      *
      * @param {string} code
-     * @returns {string | null}
+     * @returns {boolean}
      */
-    var checkInvalidSystemClassCalls = function(code) {
-      var systemClassName = SYSTEM_AUXILIARY_CLASSES.python.systemClass;
-      var auxiliaryClassName = SYSTEM_AUXILIARY_CLASSES.python.auxiliaryClass;
-      var auxiliaryClassRegEx = new RegExp('\\b' + auxiliaryClassName + '\\b');
-      var systemClassRegEx = new RegExp('\\b' + systemClassName + '\\b');
-      if (auxiliaryClassRegEx.exec(code)) {
-        return AUXILIARYCODE_CALL;
-      } else if (systemClassRegEx.exec(code)) {
-        return SYSTEM_CALL;
-      } else {
-        return null;
-      }
+    var hasInvalidSystemClassCalls = function(code) {
+      var systemClassRegEx = new RegExp('\\b' + CLASS_NAME_SYSTEM_CODE + '\\b');
+
+      return (systemClassRegEx.exec(code) !== null);
+    };
+
+    /**
+     * Returns whether the user tries to call the AuxiliaryCode class or its
+     * methods in the given code.
+     *
+     * @param {string} code
+     * @returns {boolean}
+     */
+    var hasInvalidAuxiliaryClassCalls = function(code) {
+      var auxiliaryClassRegEx = new RegExp('\\b' + CLASS_NAME_AUXILIARY_CODE +
+        '\\b');
+
+      return (auxiliaryClassRegEx.exec(code) !== null);
     };
 
     return {
@@ -192,10 +195,12 @@ tie.factory('PythonPrereqCheckService', [
             PREREQ_CHECK_TYPE_GLOBAL_CODE, null, starterCode);
         }
 
-        if (checkInvalidSystemClassCalls(code) === SYSTEM_CALL) {
+        if (hasInvalidSystemClassCalls(code)) {
           return PrereqCheckFailureObjectFactory.create(
             PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL, null, null);
-        } else if (checkInvalidSystemClassCalls(code) === AUXILIARYCODE_CALL) {
+        }
+
+        if (hasInvalidAuxiliaryClassCalls(code)) {
           return PrereqCheckFailureObjectFactory.create(
             PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL, null, null);
         }
@@ -213,11 +218,12 @@ tie.factory('PythonPrereqCheckService', [
       },
       checkStarterCodeFunctionsPresent: checkStarterCodeFunctionsPresent,
       checkGlobalCallsPresent: checkGlobalCallsPresent,
-      checkInvalidSystemClassCalls: checkInvalidSystemClassCalls,
       doTopLevelFunctionLinesExist: doTopLevelFunctionLinesExist,
       extractTopLevelFunctionLines: extractTopLevelFunctionLines,
       getImportedLibraries: getImportedLibraries,
-      getUnsupportedImports: getUnsupportedImports
+      getUnsupportedImports: getUnsupportedImports,
+      hasInvalidAuxiliaryClassCalls: hasInvalidAuxiliaryClassCalls,
+      hasInvalidSystemClassCalls: hasInvalidSystemClassCalls
     };
   }
 ]);

--- a/client/services/code_evaluators/PythonPrereqCheckService.js
+++ b/client/services/code_evaluators/PythonPrereqCheckService.js
@@ -21,12 +21,12 @@ tie.factory('PythonPrereqCheckService', [
   'PrereqCheckFailureObjectFactory', 'PREREQ_CHECK_TYPE_BAD_IMPORT',
   'PREREQ_CHECK_TYPE_MISSING_STARTER_CODE', 'SUPPORTED_PYTHON_LIBS',
   'PREREQ_CHECK_TYPE_GLOBAL_CODE', 'PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL',
-  'PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL',
+  'PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL', 'SYSTEM_AUXILIARY_CLASSES',
   function(
       PrereqCheckFailureObjectFactory, PREREQ_CHECK_TYPE_BAD_IMPORT,
       PREREQ_CHECK_TYPE_MISSING_STARTER_CODE, SUPPORTED_PYTHON_LIBS,
       PREREQ_CHECK_TYPE_GLOBAL_CODE, PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL,
-      PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL) {
+      PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL, SYSTEM_AUXILIARY_CLASSES) {
     var AUXILIARYCODE_CALL = 'auxiliaryCode';
     var SYSTEM_CALL = 'system';
 
@@ -154,11 +154,13 @@ tie.factory('PythonPrereqCheckService', [
      * if neither classes' methods are called.
      *
      * @param {string} code
-     * @returns {string}
+     * @returns {string | null}
      */
     var checkInvalidSystemClassCalls = function(code) {
-      var auxiliaryClassRegEx = new RegExp('\\bAuxiliaryCode\\b');
-      var systemClassRegEx = new RegExp('\\bSystem\\b');
+      var systemClassName = SYSTEM_AUXILIARY_CLASSES.python.systemClass;
+      var auxiliaryClassName = SYSTEM_AUXILIARY_CLASSES.python.auxiliaryClass;
+      var auxiliaryClassRegEx = new RegExp('\\b' + auxiliaryClassName + '\\b');
+      var systemClassRegEx = new RegExp('\\b' + systemClassName + '\\b');
       if (auxiliaryClassRegEx.exec(code)) {
         return AUXILIARYCODE_CALL;
       } else if (systemClassRegEx.exec(code)) {

--- a/client/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -206,6 +206,39 @@ describe('PythonPrereqCheckService', function() {
     }
   );
 
+  describe('checkInvalidSystemClassCalls', function() {
+    describe('returns the correct string when', function() {
+      it('the user tries to use the System class\'s methods', function() {
+        var code = [
+          'def myFunction(arg):',
+          '    return System.runTest(StudentCode, myFunction, 0)'
+        ].join('\n');
+        expect(PythonPrereqCheckService.checkInvalidSystemClassCalls(code))
+          .toEqual('system');
+      });
+
+      it('the user tries to use AuxiliaryCode class\'s methods', function() {
+        var code = [
+          'def myFunction(arg):',
+          '    return AuxiliaryCode.matchParentheses(arg)'
+        ].join('\n');
+        expect(PythonPrereqCheckService.checkInvalidSystemClassCalls(code))
+          .toEqual('auxiliaryCode');
+      });
+    });
+
+    it('returns null when there are no invalid System or AuxiliaryCode calls',
+      function() {
+        var code = [
+          'def myFunction(arg)',
+          '    return arg'
+        ].join('\n');
+        expect(PythonPrereqCheckService.checkInvalidSystemClassCalls(code))
+          .toBeNull();
+      }
+    );
+  });
+
   describe('checkCode', function() {
     it(['returns the correct PrereqCheckFailureObject when starter code is ',
       'missing'].join(''), function() {

--- a/client/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -330,6 +330,39 @@ describe('PythonPrereqCheckService', function() {
         }
     );
 
+    it(['returns the correct PrereqCheckFailureObject when there is invalid',
+      ' System call'].join(''), function() {
+      var starterCode = [
+        'def myFunction(arg):',
+        '    return arg'
+      ].join('\n');
+      var code = [
+        'def myFunction(arg):',
+        '    return System.runTest(StudentCode, myFunction, 0)'
+      ].join('\n');
+
+      var prereqCheckFailure = PythonPrereqCheckService.checkCode(
+        starterCode, code);
+      expect(prereqCheckFailure.hasInvalidSystemCall()).toEqual(true);
+    });
+
+    it(['returns the correct PrereqCheckFailureObject when there is an invalid',
+      ' AuxiliaryCode call'].join(''), function() {
+      var starterCode = [
+        'def myFunction(arg):',
+        '    return arg'
+      ].join('\n');
+
+      var code = [
+        'def myFunction(arg):',
+        '    return AuxiliaryCode.matchParentheses(arg)'
+      ].join('\n');
+
+      var prereqCheckFailure = PythonPrereqCheckService.checkCode(
+        starterCode, code);
+      expect(prereqCheckFailure.hasInvalidAuxiliaryCodeCall()).toEqual(true);
+    });
+
     it(['returns the correct PrereqCheckFailureObject when unsupported',
       ' libraries are imported'].join(''), function() {
       var userCode = [

--- a/client/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -206,35 +206,50 @@ describe('PythonPrereqCheckService', function() {
     }
   );
 
-  describe('checkInvalidSystemClassCalls', function() {
-    describe('returns the correct string when', function() {
-      it('the user tries to use the System class\'s methods', function() {
+  describe('hasInvalidSystemClassCalls', function() {
+    it('returns true when the user tries to use the System class\'s methods',
+      function() {
         var code = [
           'def myFunction(arg):',
           '    return System.runTest(StudentCode, myFunction, 0)'
         ].join('\n');
-        expect(PythonPrereqCheckService.checkInvalidSystemClassCalls(code))
-          .toEqual('system');
-      });
+        expect(PythonPrereqCheckService.hasInvalidSystemClassCalls(code))
+            .toBe(true);
+      }
+    );
 
-      it('the user tries to use AuxiliaryCode class\'s methods', function() {
-        var code = [
-          'def myFunction(arg):',
-          '    return AuxiliaryCode.matchParentheses(arg)'
-        ].join('\n');
-        expect(PythonPrereqCheckService.checkInvalidSystemClassCalls(code))
-          .toEqual('auxiliaryCode');
-      });
-    });
-
-    it('returns null when there are no invalid System or AuxiliaryCode calls',
+    it('returns false when the user doesn\'t use a System class or method,',
       function() {
         var code = [
           'def myFunction(arg)',
           '    return arg'
         ].join('\n');
-        expect(PythonPrereqCheckService.checkInvalidSystemClassCalls(code))
-          .toBeNull();
+        expect(PythonPrereqCheckService.hasInvalidSystemClassCalls(code))
+            .toBe(false);
+      }
+    );
+  });
+
+  describe('hasInvalidAuxiliaryClassCalls', function() {
+    it('returns true when the user tries to use AuxiliaryCode class or methods',
+      function() {
+        var code = [
+          'def myFunction(arg):',
+          '    return AuxiliaryCode.matchParentheses(arg)'
+        ].join('\n');
+        expect(PythonPrereqCheckService.hasInvalidAuxiliaryClassCalls(code))
+          .toBe(true);
+      }
+    );
+
+    it('returns false when there are no AuxiliaryCode calls',
+      function() {
+        var code = [
+          'def myFunction(arg)',
+          '    return arg'
+        ].join('\n');
+        expect(PythonPrereqCheckService.hasInvalidAuxiliaryClassCalls(code))
+          .toBe(false);
       }
     );
   });


### PR DESCRIPTION
Fix to Issue #36 
* Added 2 PrereqCheckFailure types to account for invalid calls to the `System` and `AuxiliaryCode` classes
* Added new feedback for these new PrereqCheckFailure types in `FeedbackGenerator`
* Added relevant tests