### PR TITLE
Fix 368: Bottom Navbar Styling on Window Shrink

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -156,7 +156,7 @@ tie.directive('learnerView', [function() {
       <style>
         html {
           height: 100%;
-          min-height: 622px;
+          min-height: 675px;
           min-width: 1331px;
         }
         body {


### PR DESCRIPTION
Fix to Issue #368 

* Changed `html` min-height such that container divs will style the bottom navbar correctly even when window shrinks