### PR TITLE
Fix 335: Question Numbers Going Off Page

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -25,7 +25,7 @@ tie.directive('learnerView', [function() {
         <div class="tie-question-ui-outer">
           <div class="tie-question-ui-inner">
             <div class="tie-step-container-outer">
-              <div class="tie-step-container-inner">
+              <div class="tie-step-container-inner" ng-style="{'margin-right':'calc(-1*(100% / ' + questionIds.length + ' - 35px))'}">
                 <div class="tie-step-item"
                     ng-repeat="questionId in questionIds track by $index"
                     ng-click="navigateToQuestion($index)">
@@ -492,8 +492,8 @@ tie.directive('learnerView', [function() {
         }
         .tie-step-container-inner {
           display: flex;
-          margin-left: auto;
-          margin-right: auto;
+          flex-grow: 1;
+          margin-left: 8px;
           text-align: center;
         }
         .tie-step-container-outer {
@@ -511,6 +511,7 @@ tie.directive('learnerView', [function() {
         }
         .tie-step-item {
           display: flex;
+          flex-grow: 1;
         }
         .tie-step-item > .tie-step-active {
           background-color: rgb(42, 128, 255);
@@ -522,7 +523,7 @@ tie.directive('learnerView', [function() {
           margin-left: 8px;
           margin-right: 8px;
           margin-top: auto;
-          width: 128px;
+          width: calc(100% - 35px);
         }
         .tie-step-checkmark, .tie-step-text {
           font-size: 14px;


### PR DESCRIPTION
Fix to Issue #335 
* Added styling so that question numbers will all be equally spaced on page to allow them all to be presented without going off the page

Example:
![image](https://user-images.githubusercontent.com/12034267/28234267-a2dae5ac-68b2-11e7-931d-4e37637e8daf.png)
