### PR TITLE
Fix #355: Resolve Code Window Flashing

### DIFF
--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -121,7 +121,7 @@ tie.directive('learnerView', [function() {
                                    class="protractor-test-code-input">
                     </ui-codemirror>
                   </div>
-                  <div ng-if="!codeEditorIsShown" class="tie-codemirror-placeholder">
+                  <div ng-if="!codeEditorIsShown" class="tie-codemirror-container">
                     <ui-codemirror ui-codemirror-opts="codeMirrorOptions" 
                                    ng-model="editorContents.code"
                                    class="protractor-test-code-input">
@@ -230,9 +230,6 @@ tie.directive('learnerView', [function() {
           height: 100%;
         }
         .tie-codemirror-container {
-          width: 100%;
-        }
-        .tie-codemirror-placeholder {
           width: 100%;
         }
         .tie-coding-terminal {

--- a/client/components/LearnerViewDirective.js
+++ b/client/components/LearnerViewDirective.js
@@ -121,6 +121,12 @@ tie.directive('learnerView', [function() {
                                    class="protractor-test-code-input">
                     </ui-codemirror>
                   </div>
+                  <div ng-if="!codeEditorIsShown" class="tie-codemirror-placeholder">
+                    <ui-codemirror ui-codemirror-opts="codeMirrorOptions" 
+                                   ng-model="editorContents.code"
+                                   class="protractor-test-code-input">
+                    </ui-codemirror>
+                  </div>
                 </div>
                 <select class="tie-select-menu" name="lang-select-menu">
                   <option value="Python" selected>Python</option>
@@ -224,6 +230,9 @@ tie.directive('learnerView', [function() {
           height: 100%;
         }
         .tie-codemirror-container {
+          width: 100%;
+        }
+        .tie-codemirror-placeholder {
           width: 100%;
         }
         .tie-coding-terminal {


### PR DESCRIPTION
Fix to Issue #355 
* Added a "placeholder" codemirror window that would look exactly like the original code window when it is being removed and replaced in the DOM. Resolves the code window flashing problem.