### PR TITLE
Fix #370: Reinforcement Input Formatting

### DIFF
--- a/assets/questions/findMostCommonCharacter.js
+++ b/assets/questions/findMostCommonCharacter.js
@@ -92,7 +92,7 @@ class AuxiliaryCode(object):
       allowedOutputs: ['s'],
       tag: 'strings with many spaces'
     }, {
-      input: 'a b c d e f f',
+      input: 'a    b c    d e f f',
       allowedOutputs: ['f'],
       tag: 'strings with many spaces'
     }],

--- a/client/domain/ReinforcementObjectFactory.js
+++ b/client/domain/ReinforcementObjectFactory.js
@@ -64,6 +64,17 @@ tie.factory('ReinforcementObjectFactory', [
       this._pastFailedCases = {};
     };
 
+    /**
+     * Helper function that replaces spaces in string so that it will preserve
+     * any extra, consecutive space characters in Reinforcement bullet.
+     *
+     * @param {string} stringifiedInput
+     * @returns {string}
+     */
+    var formatInput = function(stringifiedInput) {
+      return stringifiedInput.replace(/ /g, '\u00A0');
+    };
+
     // Instance methods.
     /**
      * This function creates an array of ReinforcementBullet objects
@@ -141,8 +152,7 @@ tie.factory('ReinforcementObjectFactory', [
      */
     Reinforcement.prototype.addPastFailedCase = function(
         stringifiedCaseInput, casePassed) {
-      var formattedInput = stringifiedCaseInput.replace(/ /g, '\u00A0');
-      this._pastFailedCases[formattedInput] = casePassed;
+      this._pastFailedCases[formatInput(stringifiedCaseInput)] = casePassed;
     };
 
     /**
@@ -154,8 +164,7 @@ tie.factory('ReinforcementObjectFactory', [
      */
     Reinforcement.prototype.updatePastFailedCase = function(
         stringifiedCaseInput, casePassed) {
-      var formattedInput = stringifiedCaseInput.replace(/ /g, '\u00A0');
-      this._pastFailedCases[formattedInput] = casePassed;
+      this._pastFailedCases[formatInput(stringifiedCaseInput)] = casePassed;
     };
 
     /**
@@ -184,8 +193,8 @@ tie.factory('ReinforcementObjectFactory', [
      * @returns {boolean}
      */
     Reinforcement.prototype.hasPastFailedCase = function(stringifiedCaseInput) {
-      var formattedInput = stringifiedCaseInput.replace(/ /g, '\u00A0');
-      return this._pastFailedCases.hasOwnProperty(formattedInput);
+      return this._pastFailedCases.hasOwnProperty(
+        formatInput(stringifiedCaseInput));
     };
 
     // Static class methods.

--- a/client/domain/ReinforcementObjectFactory.js
+++ b/client/domain/ReinforcementObjectFactory.js
@@ -141,7 +141,8 @@ tie.factory('ReinforcementObjectFactory', [
      */
     Reinforcement.prototype.addPastFailedCase = function(
         stringifiedCaseInput, casePassed) {
-      this._pastFailedCases[stringifiedCaseInput] = casePassed;
+      var formattedInput = stringifiedCaseInput.replace(/ /g, '\u00A0');
+      this._pastFailedCases[formattedInput] = casePassed;
     };
 
     /**
@@ -153,7 +154,8 @@ tie.factory('ReinforcementObjectFactory', [
      */
     Reinforcement.prototype.updatePastFailedCase = function(
         stringifiedCaseInput, casePassed) {
-      this._pastFailedCases[stringifiedCaseInput] = casePassed;
+      var formattedInput = stringifiedCaseInput.replace(/ /g, '\u00A0');
+      this._pastFailedCases[formattedInput] = casePassed;
     };
 
     /**
@@ -182,7 +184,8 @@ tie.factory('ReinforcementObjectFactory', [
      * @returns {boolean}
      */
     Reinforcement.prototype.hasPastFailedCase = function(stringifiedCaseInput) {
-      return this._pastFailedCases.hasOwnProperty(stringifiedCaseInput);
+      var formattedInput = stringifiedCaseInput.replace(/ /g, '\u00A0');
+      return this._pastFailedCases.hasOwnProperty(formattedInput);
     };
 
     // Static class methods.

--- a/protractor_tests/question.spec.js
+++ b/protractor_tests/question.spec.js
@@ -59,7 +59,7 @@ describe('submitting questions', function() {
       '            letter = s[i]',
       '    return letter',
       ''
-    ].join('\\u000A');
+    ].join('\\n');
 
     questionsPage.submitCode(code);
 

--- a/protractor_tests/question.spec.js
+++ b/protractor_tests/question.spec.js
@@ -35,4 +35,36 @@ describe('submitting questions', function() {
   afterEach(function() {
     utils.checkForConsoleErrors([]);
   });
+
+  it('should successfully display reinforcement input', function() {
+    var questionsPage = new QuestionsPage();
+
+    questionsPage.get();
+    questionsPage.resetCode();
+
+    var code = [
+      'def findMostCommonCharacter(s):',
+      '    counter = 0',
+      '    maxCount = -1',
+      '    letter = s[0]',
+      '    for i in range(len(s)):',
+      '        if counter == 0:',
+      '            counter = 1',
+      '        elif s[i-1] == s[i]:',
+      '            counter += 1',
+      '        else:',
+      '            counter = 0',
+      '        if counter > maxCount:',
+      '            maxCount = counter',
+      '            letter = s[i]',
+      '    return letter',
+      ''
+    ].join('\\u000A');
+
+    questionsPage.submitCode(code);
+
+    expect(questionsPage.countReinforcementBullets()).toEqual(6);
+    expect(questionsPage.getReinforcementBulletText(5)).toEqual(
+      'Fails on \'"a    b c    d e f f"\'');
+  });
 });

--- a/protractor_tests/questions.pageObject.js
+++ b/protractor_tests/questions.pageObject.js
@@ -55,6 +55,14 @@ var QuestionsPage = function() {
   var runCodeBtn = element(by.css('.protractor-test-run-code-btn'));
 
   /**
+   * Set of all Reinforcement bullets rendered in the DOM.
+   *
+   * @type {Array}
+   */
+  var reinforcementBullets = element.all(by.repeater(
+    'bullet in reinforcementBullets'));
+
+  /**
    * Retrieves the TIE homepage
    */
   this.get = function() {
@@ -78,7 +86,7 @@ var QuestionsPage = function() {
   /**
    * Simulates adding the given code string to the code editor.
    *
-   * @param codeString
+   * @param {string} codeString
    */
   this.submitCode = function(codeString) {
     browser.executeScript([
@@ -106,6 +114,26 @@ var QuestionsPage = function() {
    */
   this.getFeedbackParagraphText = function(index) {
     return feedbackParagraphs.get(index).getText();
+  };
+
+  /**
+   * Returns the number of Reinforcement bullets rendered in the DOM.
+   *
+   * @returns {number}
+   */
+  this.countReinforcementBullets = function() {
+    return reinforcementBullets.count();
+  };
+
+  /**
+   * Returns the content of the reinforcement bullet at the given index in the
+   * Reinforcement bullet array.
+   *
+   * @param {number} index
+   * @returns {string}
+   */
+  this.getReinforcementBulletText = function(index) {
+    return reinforcementBullets.get(index).getText();
   };
 };
 


### PR DESCRIPTION
Fix to Issue #370 
* Added helper function and adjusted test case input formatting to ensure spaces don't get collapsed when rendering reinforcement test case input

Example of old Reinforcement bullet rendering:
![image](https://user-images.githubusercontent.com/12034267/28386702-40802958-6c81-11e7-87a1-37e03a0393f6.png)

Example of Reinforcement with proposed changes:
![image](https://user-images.githubusercontent.com/12034267/28386671-21b1ecdc-6c81-11e7-96d9-7f4f9deea862.png)

