### PR TITLE
Add require-jsdoc to linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -148,6 +148,14 @@
         "quote-props": ["error", "as-needed"],
         "radix": "error",
         "require-await": "error",
+        "require-jsdoc": ["error", {
+          "require": {
+            "FunctionDeclaration": true,
+            "MethodDefinition": true,
+            "ClassDeclaration": true,
+            "ArrowFunctionExpression": true
+          }
+        }],
         "semi": "error",
         "semi-spacing": "error",
         "sort-vars": "error",


### PR DESCRIPTION
* Added new `require-jsdoc` rule to linter so that we don't regress in adding JSDoc comments

*Note*: There's another related rule called [valid-jsdoc](http://eslint.org/docs/rules/valid-jsdoc) that enforces style and consistency within JSDoc comments. I wasn't sure whether we wanted to be that strict, and there are also a lot of ways we can specify it, which I'd love to get team input on if we do decide to go with adding this rule.