### PR TITLE
Fix Java Comment RegEx Bug

### DIFF
--- a/client/question/question.js
+++ b/client/question/question.js
@@ -248,7 +248,7 @@ tie.constant('WRONG_LANGUAGE_ERRORS', {
   }, {
     // Used the Java comment syntax
     errorName: 'javaComment',
-    regExString: '\\/(\\s*|\\w*)*\\n|\\/\\*(\\*)?(\\s*|\\w*)*\\*\\/',
+    regExString: '\\/\\/(\\s*|\\w*)*\\n|\\/\\*(\\*)?(\\s*|\\w*)*\\*\\/',
     feedbackParagraphs: [
       {
         type: 'text',

--- a/client/question/question.js
+++ b/client/question/question.js
@@ -248,7 +248,7 @@ tie.constant('WRONG_LANGUAGE_ERRORS', {
   }, {
     // Used the Java comment syntax
     errorName: 'javaComment',
-    regExString: '\\/\\/(\\s*|\\w*)*\\n|\\/\\*(\\*)?(\\s*|\\w*)*\\*\\/',
+    regExString: '\\/\\/(\\s|\\w)*\\n|\\/\\*(\\*)?(\\s|\\w)*\\*\\/',
     feedbackParagraphs: [
       {
         type: 'text',


### PR DESCRIPTION
* Fixed bug where the ZeroDivisionError would get blocked by the Java Comment Regex for Wrong Language Syntax Detection