### PR TITLE
First pass at improving reverseWords question.

### DIFF
--- a/assets/question_sets/strings.js
+++ b/assets/question_sets/strings.js
@@ -27,8 +27,8 @@ globalData.questionSets['strings'] = {  // eslint-disable-line dot-notation
     ].join('')
   ],
   questionIds: [
-    'reverseWords',
     'findMostCommonCharacter',
+    'reverseWords',
     'isPalindrome',
     'checkBalancedParentheses',
     'internationalization',

--- a/assets/question_sets/strings.js
+++ b/assets/question_sets/strings.js
@@ -27,8 +27,8 @@ globalData.questionSets['strings'] = {  // eslint-disable-line dot-notation
     ].join('')
   ],
   questionIds: [
-    'findMostCommonCharacter',
     'reverseWords',
+    'findMostCommonCharacter',
     'isPalindrome',
     'checkBalancedParentheses',
     'internationalization',

--- a/assets/questions/reverseWords.js
+++ b/assets/questions/reverseWords.js
@@ -28,124 +28,388 @@ globalData.questions['reverseWords'] = {  // eslint-disable-line dot-notation
     python:
 `class AuxiliaryCode(object):
     @classmethod
-    def forgetLastWord(cls, s):
-        result = ""
-        reversed_word = []
-        for c in s:
-            if c.isspace():
-                result += "".join(reversed(reversed_word))
-                result += c
-                reversed_word = []
-            else:
-                reversed_word.append(c)
-        return result
+    def _reverseCorrectly(cls, s, isCharValid):
+      result = ''
+      reversed_word = ''
+      for c in s:
+        if isCharValid(c):
+          result += reversed_word[::-1]
+          result += c
+          reversed_word = ''
+        else:
+          reversed_word += c
+      if reversed_word:
+        result += reversed_word[::-1]
+      return result
+
+    @classmethod
+    def _reverseCorrectlyWithGivenDelimiters(cls, s, delimiters):
+      return cls._reverseCorrectly(s, lambda x: x not in delimiters)
+
+    @classmethod
+    def returnNone(cls, s):
+      return None
+
+    @classmethod
+    def returnSampleOutput(cls, s):
+      return 'olleH, nhoJ'
 
     @classmethod
     def reverseString(cls, s):
-        return s[::-1]
+      return s[::-1]
+
+    @classmethod
+    def returnOriginalString(cls, s):
+      return s
+
+    @classmethod
+    def elideNonLetters(cls, s):
+      result = ''
+      for c in s:
+        if c.isalpha():
+          result += c
+      return result[::-1]
+
+    @classmethod
+    def forgetLastWord(cls, s):
+      result = ''
+      reversed_word = ''
+      for c in s:
+        if not c.isalpha():
+          result += reversed_word[::-1]
+          result += c
+          reversed_word = ''
+        else:
+          reversed_word += c
+      return result
+
+    @classmethod
+    def forgetToReverseLastWord(cls, s):
+      result = ''
+      reversed_word = ''
+      for c in s:
+        if not c.isalpha():
+          result += reversed_word[::-1]
+          result += c
+          reversed_word = ''
+        else:
+          reversed_word += c
+      if reversed_word:
+        result += reversed_word
+      return result
+
+    @classmethod
+    def treatCommaAsPartOfWord(cls, s):
+      return cls._reverseCorrectlyWithGivenDelimiters(s, [' '])
+
+    @classmethod
+    def addSpaceAtEnd(cls, s):
+      return cls._reverseCorrectly(s + ' ', lambda x: x.isalpha())
+
+    @classmethod
+    def treatAsciiCharsContiguously(cls, s):
+      return cls._reverseCorrectly(s, lambda x: 65 <= ord(x) <= 122)
+
+    @classmethod
+    def useWeakInequalitiesForCharValidity(cls, s):
+      return cls._reverseCorrectly(
+          s, lambda x: 65 < ord(x) < 90 or 97 < ord(x) < 122)
+
+    @classmethod
+    def treatsNumbersAsValidLetters(cls, s):
+      return cls._reverseCorrectly(s, lambda x: isalpha(x) or isdigit(x))
 `
   },
   tasks: [{
-    instructions: [
-      {
-        content: [
-          'For this question, you\'ll implement the reverseWords function. ',
-          'This function takes a string of words separated by whitespace and ',
-          'reverses the non-whitespace characters in the words, but not the ',
-          'words\' ordering. It should also preserve the original whitespace.'
-        ].join(''),
-        type: 'text'
-      },
-      {
-        content: 'Input: "moo cow bark dog"\nOutput: "oom woc krab god"',
-        type: 'code'
-      }
-    ],
-    prerequisiteSkills: ['Arrays', 'Strings', 'String Manipulation'],
+    instructions: [{
+      content: [
+        'For this question, you\'ll implement the reverseWords function. ',
+        'This function takes a string of words and reverses the individual ',
+        'words, but it does not change the ordering of the words within the ',
+        'sentence. All the original whitespace/punctuation should be ',
+        'preserved. Here\'s an example:'
+      ].join(''),
+      type: 'text'
+    }, {
+      content: 'Input: "Hello, John"\nOutput: "olleH, nhoJ"',
+      type: 'code'
+    }],
+    prerequisiteSkills: ['Strings', 'String Manipulation'],
     acquiredSkills: ['String Manipulation'],
     inputFunctionName: null,
     outputFunctionName: null,
     mainFunctionName: 'reverseWords',
     correctnessTests: [{
-      input: 'moo cow bark dog',
-      allowedOutputs: ['oom woc krab god'],
+      input: 'Hello, John',
+      allowedOutputs: ['olleH, nhoJ'],
+      tag: 'the sample input'
+    }, {
+      input: 'Hi, world',
+      allowedOutputs: ['iH, dlrow'],
       tag: 'the general case'
     }, {
-      input: 'racecar civic kayak mom noon level',
-      allowedOutputs: ['racecar civic kayak mom noon level'],
+      input: 'Hello, world',
+      allowedOutputs: ['olleH, dlrow'],
       tag: 'the general case'
     }, {
-      input: 'I',
-      allowedOutputs: ['I'],
-      tag: 'short strings'
+      input: 'Hey, how are you',
+      allowedOutputs: ['yeH, woh era uoy'],
+      tag: 'the sample input'
+    }, {
+      input: '  hello  ',
+      allowedOutputs: ['  olleh  '],
+      tag: 'strings with lots of whitespace'
+    }, {
+      input: 'hello  world',
+      allowedOutputs: ['olleh  dlrow'],
+      tag: 'strings with lots of whitespace'
+    }, {
+      input: 'hello    ',
+      allowedOutputs: ['olleh    '],
+      tag: 'strings with lots of whitespace'
+    }, {
+      input: 'Hi-- John',
+      allowedOutputs: ['iH-- nhoJ'],
+      tag: 'strings with punctuation'
+    }, {
+      input: 'Hi$ John',
+      allowedOutputs: ['iH$ nhoJ'],
+      tag: 'strings with punctuation'
+    }, {
+      input: 'Hi , John',
+      allowedOutputs: ['iH , nhoJ'],
+      tag: 'strings with punctuation'
+    }, {
+      input: '+one+two',
+      allowedOutputs: ['+eno+owt'],
+      tag: 'strings with punctuation'
+    }, {
+      input: 'Hello.goodbye',
+      allowedOutputs: ['olleH.eybdoog'],
+      tag: 'strings with punctuation'
+    }, {
+      input: 'Hi[ John',
+      allowedOutputs: ['iH[ nhoJ'],
+      tag: 'corner cases'
+    }, {
+      input: 'Hi Antoine',
+      allowedOutputs: ['iH eniotnA'],
+      tag: 'corner cases'
+    }, {
+      input: 'Hi antoine',
+      allowedOutputs: ['iH eniotna'],
+      tag: 'corner cases'
+    }, {
+      input: 'Hi Zaphod',
+      allowedOutputs: ['iH dohpaZ'],
+      tag: 'corner cases'
+    }, {
+      input: 'Hi 007',
+      allowedOutputs: ['iH 007'],
+      tag: 'corner cases'
+    }, {
+      input: 'H1 John',
+      allowedOutputs: ['H1 nhoJ'],
+      tag: 'corner cases'
+    }, {
+      input: 'Hello',
+      allowedOutputs: ['olleH'],
+      tag: 'corner cases'
+    }, {
+      input: 'hi',
+      allowedOutputs: ['ih'],
+      tag: 'corner cases'
+    }, {
+      input: 'a',
+      allowedOutputs: ['a'],
+      tag: 'corner cases'
+    }, {
+      input: 'A',
+      allowedOutputs: ['A'],
+      tag: 'corner cases'
+    }, {
+      input: ' ',
+      allowedOutputs: [' '],
+      tag: 'corner cases'
+    }, {
+      input: '  ',
+      allowedOutputs: ['  '],
+      tag: 'corner cases'
     }, {
       input: '',
       allowedOutputs: [''],
-      tag: 'empty strings'
+      tag: 'corner cases'
     }, {
-      input: 'ab',
-      allowedOutputs: ['ba'],
-      tag: 'short strings'
+      input: '..,. !?',
+      allowedOutputs: ['..,. !?'],
+      tag: 'corner cases'
+    }, {
+      input: '123',
+      allowedOutputs: ['123'],
+      tag: 'corner cases'
+    }, {
+      input: 'hello,,, how are you?',
+      allowedOutputs: ['olleh,,, woh era uoy?'],
+      tag: 'corner cases'
+    }, {
+      input: 'Hello.,.!?world',
+      allowedOutputs: ['olleH.,.!?dlrow'],
+      tag: 'corner cases'
+    }, {
+      input: 'Hello---john',
+      allowedOutputs: ['olleH---nhoj'],
+      tag: 'corner cases'
+    }, {
+      input: '...hello..goodbye...',
+      allowedOutputs: ['...olleh..eybdoog...'],
+      tag: 'corner cases'
     }],
     buggyOutputTests: [{
-      buggyFunctionName: 'AuxiliaryCode.forgetLastWord',
+      buggyFunctionName: 'AuxiliaryCode.returnNone',
       messages: [
-        "Try running your code on 'river ocean' on paper. What's the result?",
-        "Are you sure that you're reversing all the words?",
+        'What value does your code return when given the input "Hello, John"?',
         [
-          "It looks like you're exiting the function without adding on the ",
-          "last reversed word."
+          "It looks like your code isn't returning anything. Do you need to ",
+          "add a return statement?"
+        ].join('')
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.returnSampleOutput',
+      messages: [
+        [
+          'Your code should work in the general case, not just the one given ',
+          'in the sample input/output.'
+        ].join(''),
+        [
+          'Looks like your code always returns the same result, even for ',
+          'different input strings! However, the code needs to work ',
+          'correctly for any input string.'
         ].join('')
       ]
     }, {
       buggyFunctionName: 'AuxiliaryCode.reverseString',
       messages: [
         [
-          "Whoops! It looks like you're reversing the entire string, but you ",
-          "should only be reversing each word in turn, not their ordering. ",
-          "Please check the given example, and try again."
+          "Try reading the question again, and looking at the sample ",
+          "input/output -- it's asking for something different."
+        ].join(''),
+        [
+          'For the sample input "Hello, John", the expected output is "olleH, ',
+          'nhoJ". Can you verify the first letter of the return value ',
+          'produced by your code?'
+        ].join(''),
+        [
+          'The question asks to reverse each individual word in the string, ',
+          'but preserve the order of the words. However, it looks like your ',
+          'code is reversing the entire string...'
         ].join('')
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.returnOriginalString',
+      messages: [
+        [
+          'Try running your algorithm, by hand, on the sample input. Does it ',
+          'give the right answer?'
+        ].join(''),
+        [
+          'When your code is run with "Hello, John", where does the "H" at ',
+          'the beginning end up?'
+        ].join(''),
+        [
+          'Your code seems to be returning the original input string. There ',
+          'may be a bug in your algorithm for reversing a string -- try ',
+          'tracing through just that part of the code with a single word and ',
+          'seeing what the output is.'
+        ].join('')
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.elideNonLetters',
+      messages: [
+        [
+          'Try running your algorithm, by hand, on the sample input. Does it ',
+          'give the right answer?'
+        ].join(''),
+        [
+          "Please check that you're handling spaces correctly."
+        ].join(''),
+        [
+          'Spaces and punctuation need to be preserved. If there is a space ',
+          'between two words in the input, there should also be a space ',
+          'between those words in the output.'
+        ].join('')
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.forgetLastWord',
+      messages: [
+        [
+          'Try running your algorithm, by hand, on the sample input. Does it ',
+          'give the right answer?'
+        ].join(''),
+        [
+          "It looks like you're returning too few words. Did you forget to ",
+          "add the last one?"
+        ].join('')
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.forgetToReverseLastWord',
+      messages: [
+        [
+          'Try running your algorithm, by hand, on the sample input. Does it ',
+          'give the right answer?'
+        ].join(''),
+        [
+          'When your code is run with "Hello, John", where does the last ',
+          'character end up?'
+        ].join(''),
+        'Looks like you may have forgotten to reverse the last word...'
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.treatCommaAsPartOfWord',
+      messages: [
+        [
+          'When you run your algorithm with "Hello, John", what is the first ',
+          'character in the output? Is it correct?'
+        ].join(''),
+        [
+          'Remember, per the question, that commas, spaces, etc. should be ',
+          'left in place.'
+        ].join(''),
+        [
+          'Your code seems to treat "Hello," as one word, but the comma at ',
+          'the end is not part of the word.'
+        ].join('')
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.addSpaceAtEnd',
+      messages: [
+        [
+          'Adding spaces at ends of words to keep things simple is a nice ',
+          'idea, but be careful about how you handle the extra space at the ',
+          'end.'
+        ].join('')
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.treatAsciiCharsContiguously',
+      messages: [
+        [
+          'Check the ASCII tables -- are you sure that "A"-"z" be treated as ',
+          'a contiguous block of characters?'
+        ].join('')
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.useWeakInequalitiesForCharValidity',
+      messages: [
+        [
+          'Are you correctly handling the check for whether a character is a ',
+          'valid letter?'
+        ].join('')
+      ]
+    }, {
+      buggyFunctionName: 'AuxiliaryCode.useWeakInequalitiesForCharValidity',
+      messages: [
+        'Note that numbers should not be treated as English words.'
       ]
     }],
     performanceTests: []
-  }, {
-    instructions: [
-      {
-        content: [
-          'Next, double-check your code to make sure that it preserves ',
-          'the original whitespace and handles more than just letters.'
-        ].join(''),
-        type: 'text'
-      }
-    ],
-    prerequisiteSkills: ['Arrays', 'Strings', 'String Manipulation'],
-    acquiredSkills: ['String Manipulation', 'Sets', 'Arrays', 'Maps'],
-    inputFunctionName: null,
-    outputFunctionName: null,
-    mainFunctionName: 'reverseWords',
-    correctnessTests: [{
-      input: '   this  is \t a    whitespace  test',
-      allowedOutputs: ['   siht  si \t a    ecapsetihw  tset'],
-      tag: 'the general case'
-    }, {
-      input: '\t  ',
-      allowedOutputs: ['\t  '],
-      tag: 'whitespace only strings'
-    }, {
-      input: '123 456 789 ',
-      allowedOutputs: ['321 654 987 '],
-      tag: 'numbers'
-    }, {
-      input: 'test for dashes-and others',
-      allowedOutputs: ['tset rof dna-sehsad srehto'],
-      tag: 'dashed words'
-    }],
-    buggyOutputTests: [],
-    performanceTests: [{
-      inputDataAtom: 'meow ',
-      transformationFunctionName: 'System.extendString',
-      expectedPerformance: 'linear',
-      evaluationFunctionName: 'reverseWords'
-    }]
   }]
 };

--- a/assets/questions/reverseWords.js
+++ b/assets/questions/reverseWords.js
@@ -392,8 +392,8 @@ globalData.questions['reverseWords'] = {  // eslint-disable-line dot-notation
       buggyFunctionName: 'AuxiliaryCode.treatAsciiCharsContiguously',
       messages: [
         [
-          'Check the ASCII tables -- are you sure that "A"-"z" be treated as ',
-          'a contiguous block of characters?'
+          'Check the ASCII tables -- are you sure that "A"-"z" can be ',
+          'treated as a contiguous block of characters?'
         ].join('')
       ]
     }, {

--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -265,6 +265,7 @@ tie.directive('learnerView', [function() {
         }
         .tie-dot-container{
           height: 100%;
+          margin-top: 18px;
         }
         .tie-dot.night-mode {
           background-color: #E0E0E0;

--- a/client/question/domain/FeedbackObjectFactory.js
+++ b/client/question/domain/FeedbackObjectFactory.js
@@ -169,7 +169,8 @@ tie.factory('FeedbackObjectFactory', [
 
     /**
      * Appends the feedback paragraphs in the given Feedback object to the
-     * current feedback.
+     * current feedback. If the appended feedback contains a hint index, that
+     * index is updated too.
      *
      * @param {Feedback} feedbackToAppend
      */
@@ -178,6 +179,11 @@ tie.factory('FeedbackObjectFactory', [
       paragraphsToAppend.forEach(function(paragraph) {
         this._paragraphs.push(paragraph);
       }.bind(this));
+
+      var appendedHintIndex = feedbackToAppend.getHintIndex();
+      if (appendedHintIndex !== null) {
+        this.setHintIndex(appendedHintIndex);
+      }
     };
 
     // Static class methods.


### PR DESCRIPTION
This is a first pass at adding more feedback to the reverseWords question. There's yet more feedback that can be added, but I'm blocked by a lack of functionality, so I figured I'd submit this first, add the missing functionality, and then do another pass at adding more feedback.

I also found and fixed a couple of existing bugs (@theresa-lee PTAL):
- hintIndex was not being carried over when the code received "don't use print statements" feedback, so only the first message of a feedback set was ever being shown. This resulted in a frustrating UX since the later feedback was never reached.
- The loading dots were overlapping the reinforcements, which looked ugly. I gave them a top margin.

The additional functionality I plan to add in future PRs is the following:
- After giving a sequence of hints, show "you output X but we expected Y", so at least it's clear exactly which input is failing.
- Allow custom feedback to be provided, based on which _test suites_ passed/failed.
- Allow buggy output tests to be run on only a subset of the test suites. This is because the code could fail in one way for some of the "easier" test suites, which allows appropriate feedback to be given -- but then fail in multiple ways for the "corner case" tests depending on how buggy the implementation is. This makes it hard to write custom buggy functions to catch such errors, since currently all buggy functions run on all test suites.