### PR TITLE
Fix #412: just import everything at the outset.

### DIFF
--- a/client/question/question.js
+++ b/client/question/question.js
@@ -113,7 +113,14 @@ tie.constant('FEEDBACK_CATEGORIES', [
  */
 tie.constant('SYSTEM_CODE', {
   python: [
+    'import collections',
     'import copy',
+    'import image',
+    'import math',
+    'import operator',
+    'import random',
+    'import re',
+    'import string',
     'import time',
     '',
     '# A copy of the most-recently processed input item. This is useful',


### PR DESCRIPTION
Hi @rabidbit -- I took a quick look at this. Turns out what was happening was that the imports were being placed at class-level:

    class StudentCode(object):
        import X
        import Y

        def run():
             # student's code goes here

and for some reason Skulpt wasn't finding them. On investigation, just importing everything that's supported at the top of the file seems to be the simplest way to handle this, so I went ahead and modified the starter code instead so that collections, math, etc. are automatically available.

The one thing I'm not sure about is whether we want to put a comment at the top of the coding area to say something like this:

```
    # This is a Python environment that you can type code into. The following
    # libraries have already been pre-imported and can be used if you need them:
    # collections, copy, image, math, operator, ...
```

but I'm not sure. On the one hand it gives info that might be useful. On the other hand I don't want to create the suggestion that the user should be using something from here, and it's not something an interviewer would say. My current leaning is to not have it for now, but add it later if we detect confusion (hopefully the PR as-is will address most of the issues since there won't be random import errors showing up). Wdyt?