### PR TITLE
Do not trim code while preprocessing, in order to preserve line numbers.

### DIFF
--- a/client/question/services/code_preprocessors/PythonCodePreprocessorService.js
+++ b/client/question/services/code_preprocessors/PythonCodePreprocessorService.js
@@ -176,7 +176,7 @@ tie.factory('PythonCodePreprocessorService', [
     var _transformCodeToInstanceMethods = function(code, wrapperClassName) {
       var wrappedCode = _addClassWrappingToHelperFunctions(
         code, wrapperClassName, true);
-      var codeLines = wrappedCode.trim().split('\n');
+      var codeLines = wrappedCode.split('\n');
       var subsequentLines = codeLines.map(function(line) {
         if (line.indexOf('def') === 0) {
           var leftParenIndex = line.indexOf('(');

--- a/client/question/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
+++ b/client/question/services/code_preprocessors/PythonCodePreprocessorServiceSpec.js
@@ -294,7 +294,7 @@ describe('PythonCodePreprocessorService', function() {
       ).toEqual(expectedTransformedCode);
     });
 
-    it('should trim whitespace at the ends, but preserve it between functions',
+    it('should preserve whitespace',
       function() {
         var rawCode = [
           '',
@@ -312,13 +312,18 @@ describe('PythonCodePreprocessorService', function() {
         ].join('\n');
 
         var expectedTransformedCode = [
+          '    ',
+          '    ',
           '    def funcOne(self, a, b):',
           '        x = 3',
           '    ',
           '    ',
           '    ',
           '    def funcTwo(self, c):',
-          '        d = 4'
+          '        d = 4',
+          '    ',
+          '    ',
+          '    '
         ].join('\n');
 
         expect(


### PR DESCRIPTION
I noticed this bug while running code in which the last line was a comment, e.g.:

```
def reverseWords(s):
    return s
    # print
```

Because we now strip comments in order to avoid false-positive checks, additional trimming causes the number of lines to change. The app would therefore end up hanging, due to an error check in the CodeSubmission object that was meant to verify that the number of lines in the preprocessed code stayed the same. This PR fixes that by removing the trim().