### PR TITLE
Introduce the concept of tips, i.e. non-blocking feedback.

### DIFF
--- a/client/question/domain/FeedbackObjectFactory.js
+++ b/client/question/domain/FeedbackObjectFactory.js
@@ -42,12 +42,20 @@ tie.factory('FeedbackObjectFactory', [
       }
 
       /**
+       * List of FeedbackParagraph objects to be shown as tips.
+       *
+       * @type {Array}
+       * @private
+       */
+      this._tipParagraphs = [];
+
+      /**
        * List of FeedbackParagraph objects associated with this feedback.
        *
        * @type {Array}
        * @private
        */
-      this._paragraphs = [];
+      this._feedbackParagraphs = [];
 
       /**
        * Records index of what message was displayed with this feedback.
@@ -75,13 +83,14 @@ tie.factory('FeedbackObjectFactory', [
 
     // Instance methods.
     /**
-     * A getter for the _paragraphs property.
-     * Should return an Array of FeedbackParagraph objects.
+     * Retrieves the list of tips and paragraphs associated with this Feedback
+     * object.
      *
-     * @returns {Array}
+     * @returns {Array} An array of FeedbackParagraph objects, comprising tips
+     *   followed by feedback.
      */
     Feedback.prototype.getParagraphs = function() {
-      return this._paragraphs;
+      return this._tipParagraphs.concat(this._feedbackParagraphs);
     };
 
     /**
@@ -95,13 +104,13 @@ tie.factory('FeedbackObjectFactory', [
     };
 
     /**
-     * Prepends a FeedbackParagraph of type text to the _paragraphs Array.
+     * Sets the list of tip paragraphs that are included with this feedback.
      *
-     * @param {string} text String to be inserted in text paragraph
+     * @param {Array} tipParagraphs List of FeedbackParagraph objects
+     *   representing tips to prepend to the feedback shown to the learner.
      */
-    Feedback.prototype.prependTextParagraph = function(text) {
-      this._paragraphs.unshift(
-        FeedbackParagraphObjectFactory.createTextParagraph(text));
+    Feedback.prototype.setTipParagraphs = function(tipParagraphs) {
+      this._tipParagraphs = angular.copy(tipParagraphs);
     };
 
     /**
@@ -110,7 +119,7 @@ tie.factory('FeedbackObjectFactory', [
      * @param {string} text String to be inserted in text paragraph
      */
     Feedback.prototype.appendTextParagraph = function(text) {
-      this._paragraphs.push(
+      this._feedbackParagraphs.push(
         FeedbackParagraphObjectFactory.createTextParagraph(text));
     };
 
@@ -120,10 +129,10 @@ tie.factory('FeedbackObjectFactory', [
      * @param {string} code String of code to be inserted into code paragraph
      */
     Feedback.prototype.appendCodeParagraph = function(code) {
-      if (this._paragraphs.length === 0) {
+      if (this._feedbackParagraphs.length === 0) {
         throw Error('The first feedback paragraph should be a text paragraph.');
       }
-      this._paragraphs.push(
+      this._feedbackParagraphs.push(
         FeedbackParagraphObjectFactory.createCodeParagraph(code));
     };
 
@@ -134,7 +143,7 @@ tie.factory('FeedbackObjectFactory', [
      * @param {string} text String describing the syntax error
      */
     Feedback.prototype.appendSyntaxErrorParagraph = function(text) {
-      this._paragraphs.push(
+      this._feedbackParagraphs.push(
         FeedbackParagraphObjectFactory.createSyntaxErrorParagraph(text));
     };
 
@@ -142,7 +151,7 @@ tie.factory('FeedbackObjectFactory', [
      * Clears all FeedbackParagraph objects from the _paragraphs property.
      */
     Feedback.prototype.clear = function() {
-      this._paragraphs.length = 0;
+      this._feedbackParagraphs.length = 0;
     };
 
     /**
@@ -206,7 +215,7 @@ tie.factory('FeedbackObjectFactory', [
     Feedback.prototype.appendFeedback = function(feedbackToAppend) {
       var paragraphsToAppend = feedbackToAppend.getParagraphs();
       paragraphsToAppend.forEach(function(paragraph) {
-        this._paragraphs.push(paragraph);
+        this._feedbackParagraphs.push(paragraph);
       }.bind(this));
 
       var appendedHintIndex = feedbackToAppend.getHintIndex();
@@ -222,7 +231,7 @@ tie.factory('FeedbackObjectFactory', [
      * @returns [{string, Object}] The feedback paragraphs list of dicts.
      */
     Feedback.prototype.getParagraphsAsListOfDicts = function() {
-      return this._paragraphs.map(function(paragraph) {
+      return this._feedbackParagraphs.map(function(paragraph) {
         return paragraph.toDict();
       });
     };

--- a/client/question/domain/FeedbackObjectFactorySpec.js
+++ b/client/question/domain/FeedbackObjectFactorySpec.js
@@ -17,21 +17,25 @@
  */
 
 describe('FeedbackObjectFactory', function() {
-  var FeedbackObjectFactory;
-  var feedback;
-
   var PARAGRAPH_TYPE_TEXT;
   var PARAGRAPH_TYPE_CODE;
   var PARAGRAPH_TYPE_SYNTAX_ERROR;
   var FEEDBACK_CATEGORIES;
+
+  var FeedbackObjectFactory;
+  var FeedbackParagraphObjectFactory;
+  var feedback;
 
   beforeEach(module('tie'));
   beforeEach(inject(function($injector) {
     PARAGRAPH_TYPE_TEXT = $injector.get('PARAGRAPH_TYPE_TEXT');
     PARAGRAPH_TYPE_CODE = $injector.get('PARAGRAPH_TYPE_CODE');
     PARAGRAPH_TYPE_SYNTAX_ERROR = $injector.get('PARAGRAPH_TYPE_SYNTAX_ERROR');
-    FeedbackObjectFactory = $injector.get('FeedbackObjectFactory');
     FEEDBACK_CATEGORIES = $injector.get('FEEDBACK_CATEGORIES');
+
+    FeedbackObjectFactory = $injector.get('FeedbackObjectFactory');
+    FeedbackParagraphObjectFactory = $injector.get(
+      'FeedbackParagraphObjectFactory');
     feedback = FeedbackObjectFactory.create(FEEDBACK_CATEGORIES.SUCCESSFUL);
   }));
 
@@ -62,6 +66,35 @@ describe('FeedbackObjectFactory', function() {
         feedback.appendCodeParagraph("code");
       };
       expect(errorFunction).toThrowError(Error);
+    });
+  });
+
+  describe('setTipParagraphs', function() {
+    it('should prepend tip paragraphs to feedback', function() {
+      feedback = FeedbackObjectFactory.create(FEEDBACK_CATEGORIES.SYNTAX_ERROR);
+      feedback.appendTextParagraph('testA');
+
+      var paragraphs = feedback.getParagraphs();
+      expect(paragraphs.length).toEqual(1);
+      expect(paragraphs[0].isTextParagraph()).toBe(true);
+      expect(paragraphs[0].getContent()).toEqual('testA');
+
+      feedback.setTipParagraphs([]);
+      paragraphs = feedback.getParagraphs();
+      expect(paragraphs.length).toEqual(1);
+      expect(paragraphs[0].isTextParagraph()).toBe(true);
+      expect(paragraphs[0].getContent()).toEqual('testA');
+
+      feedback.setTipParagraphs([FeedbackParagraphObjectFactory.fromDict({
+        type: 'text',
+        content: 'tip'
+      })]);
+      paragraphs = feedback.getParagraphs();
+      expect(paragraphs.length).toEqual(2);
+      expect(paragraphs[0].isTextParagraph()).toBe(true);
+      expect(paragraphs[0].getContent()).toEqual('tip');
+      expect(paragraphs[1].isTextParagraph()).toBe(true);
+      expect(paragraphs[1].getContent()).toEqual('testA');
     });
   });
 

--- a/client/question/question.html
+++ b/client/question/question.html
@@ -69,6 +69,7 @@
     <script src="services/ServerHandlerService.js"></script>
     <script src="services/SessionIdService.js"></script>
     <script src="services/SolutionHandlerService.js"></script>
+    <script src="services/TipsGeneratorService.js"></script>
     <script src="services/TranscriptService.js"></script>
     <script src="services/ReinforcementGeneratorService.js"></script>
     <script src="services/code_evaluators/CodeRunnerDispatcherService.js"></script>

--- a/client/question/question.js
+++ b/client/question/question.js
@@ -425,6 +425,27 @@ tie.constant('WRONG_LANGUAGE_ERRORS', {
   }]
 });
 
+/**
+ * Dictionary of system-generated tips.
+ *
+ * @type {{}}
+ */
+tie.constant('SYSTEM_GENERATED_TIPS', {
+  python: [{
+    // Included a print statement
+    type: 'print',
+    regExString: '\\bprint\\b',
+    feedbackParagraphs: [{
+      type: 'text',
+      content: [
+        'We noticed that you\'re using a print statement within your code. ',
+        'Since you will not be able to use such statements in a technical ',
+        'interview, TIE does not support this feature. We encourage you to ',
+        'instead step through your code by hand.'
+      ].join('')
+    }]
+  }]
+});
 
 /**
  * Pre-requisite check error type to see if the user tried to use any methods

--- a/client/question/questionSpec.js
+++ b/client/question/questionSpec.js
@@ -40,7 +40,7 @@ describe('question.js', function() {
   }));
 
   describe('WRONG_LANGUAGE_ERRORS', function() {
-    it('should have a valid and consistent internal structure', function() {
+    it('should have the correct keys and valid values', function() {
       WRONG_LANGUAGE_ERRORS.python.forEach(function(error) {
         expect(typeof error.errorName).toBe('string');
         expect(typeof error.regExString).toBe('string');
@@ -58,7 +58,7 @@ describe('question.js', function() {
   });
 
   describe('SYSTEM_GENERATED_TIPS', function() {
-    it('should have a valid and consistent internal structure', function() {
+    it('should have the correct keys and valid values', function() {
       SYSTEM_GENERATED_TIPS.python.forEach(function(tip) {
         expect(typeof tip.type).toBe('string');
         expect(typeof tip.regExString).toBe('string');
@@ -75,7 +75,7 @@ describe('question.js', function() {
   });
 
   describe('RUNTIME_ERROR_FEEDBACK_MESSAGES', function() {
-    it('should have a valid and consistent internal structure', function() {
+    it('should have the correct keys and valid values', function() {
       RUNTIME_ERROR_FEEDBACK_MESSAGES.python.forEach(function(error) {
         expect(error.checker('test')).toBe(false);
         expect(typeof error.generateMessage(['NameError: name \'key\' is not ',

--- a/client/question/questionSpec.js
+++ b/client/question/questionSpec.js
@@ -22,6 +22,8 @@ describe('question.js', function() {
   var PARAGRAPH_TYPE_SYNTAX_ERROR;
   var RUNTIME_ERROR_FEEDBACK_MESSAGES;
   var FEEDBACK_CATEGORIES;
+  var SYSTEM_GENERATED_TIPS;
+  var ALLOWED_PARAGRAPH_TYPES;
 
   beforeEach(module('tie'));
   beforeEach(inject(function($injector) {
@@ -32,6 +34,9 @@ describe('question.js', function() {
     RUNTIME_ERROR_FEEDBACK_MESSAGES = $injector.get(
       'RUNTIME_ERROR_FEEDBACK_MESSAGES');
     FEEDBACK_CATEGORIES = $injector.get('FEEDBACK_CATEGORIES');
+    SYSTEM_GENERATED_TIPS = $injector.get('SYSTEM_GENERATED_TIPS');
+    ALLOWED_PARAGRAPH_TYPES = [
+      PARAGRAPH_TYPE_CODE, PARAGRAPH_TYPE_TEXT, PARAGRAPH_TYPE_SYNTAX_ERROR];
   }));
 
   describe('WRONG_LANGUAGE_ERRORS', function() {
@@ -41,15 +46,28 @@ describe('question.js', function() {
         expect(typeof error.regExString).toBe('string');
         expect(typeof error.allowMultiline).toBe('boolean');
         expect(Array.isArray(error.feedbackParagraphs)).toBe(true);
+
         error.feedbackParagraphs.forEach(function(paragraph) {
           expect(typeof paragraph.type).toEqual('string');
-          var equalsTypeText = paragraph.type === PARAGRAPH_TYPE_TEXT;
-          var equalsTypeCode = paragraph.type === PARAGRAPH_TYPE_CODE;
-          var equalsTypeSyntaxError =
-              paragraph.type === PARAGRAPH_TYPE_SYNTAX_ERROR;
-          expect(equalsTypeCode || equalsTypeText || equalsTypeSyntaxError)
-              .toBe(true);
+          expect(ALLOWED_PARAGRAPH_TYPES.indexOf(paragraph.type) !== -1).toBe(
+            true);
+          expect(typeof paragraph.content).toEqual('string');
+        });
+      });
+    });
+  });
 
+  describe('SYSTEM_GENERATED_TIPS', function() {
+    it('should have a valid and consistent internal structure', function() {
+      SYSTEM_GENERATED_TIPS.python.forEach(function(tip) {
+        expect(typeof tip.type).toBe('string');
+        expect(typeof tip.regExString).toBe('string');
+        expect(Array.isArray(tip.feedbackParagraphs)).toBe(true);
+
+        tip.feedbackParagraphs.forEach(function(paragraph) {
+          expect(typeof paragraph.type).toEqual('string');
+          expect(ALLOWED_PARAGRAPH_TYPES.indexOf(paragraph.type) !== -1).toBe(
+            true);
           expect(typeof paragraph.content).toEqual('string');
         });
       });

--- a/client/question/services/FeedbackGeneratorService.js
+++ b/client/question/services/FeedbackGeneratorService.js
@@ -438,37 +438,6 @@ tie.factory('FeedbackGeneratorService', [
         return '';
       }
     };
-
-    /**
-     * Returns boolean indicating if there are print statements found in
-     * the given code.
-     *
-     * @param {string} code User's submitted code
-     * @returns {boolean} Indicates if there are print statements in code or not
-     */
-    var _hasPrintStatement = function(code) {
-      var printRegEx = /\bprint\b/;
-      return code.search(printRegEx) !== -1;
-    };
-
-    /**
-     * Prepends a text feedback paragraph warning against use of print
-     * statements to the given Feedback object and returns the new Feedback
-     * object.
-     *
-     * @param {Feedback} feedback
-     * @returns {Feedback}
-     */
-    var _prependPrintFeedback = function(feedback) {
-      feedback.prependTextParagraph([
-        'We noticed that you\'re using a print statement within your code. ',
-        'Since you will not be able to use such statements in a technical ',
-        'interview, TIE does not support this feature. We encourage you to ',
-        'instead step through your code by hand.'
-      ].join(''));
-      return feedback;
-    };
-
     /**
      * Returns the Feedback object associated with a given user submission
      * not including the reinforcement.
@@ -585,6 +554,8 @@ tie.factory('FeedbackGeneratorService', [
        * code submission and their test results. This also includes feedback
        * for print statements.
        *
+       * @param {Array} tipParagraphs A list of FeedbackParagraph objects
+       *   representing tips to include in the feedback.
        * @param {Array} tasks Tasks associated with the problem that include
        *    the tests the user's code must pass.
        * @param {CodeEvalResult} codeEvalResult Test results for this submission
@@ -592,7 +563,8 @@ tie.factory('FeedbackGeneratorService', [
        *    submission. Should be an array of numbers.
        * @returns {Feedback}
        */
-      getFeedback: function(tasks, codeEvalResult, rawCodeLineIndexes) {
+      getFeedback: function(
+          tipParagraphs, tasks, codeEvalResult, rawCodeLineIndexes) {
         // If the user receives the same error message increment the same error
         // counter.
         if (previousRuntimeErrorString &&
@@ -604,6 +576,7 @@ tie.factory('FeedbackGeneratorService', [
 
         var feedback = _getFeedbackWithoutReinforcement(
           tasks, codeEvalResult, rawCodeLineIndexes);
+        feedback.setTipParagraphs(tipParagraphs);
         if (tasks.length > 0 && !codeEvalResult.getErrorString()) {
           feedback.setReinforcement(
             ReinforcementGeneratorService.getReinforcement(
@@ -613,28 +586,24 @@ tie.factory('FeedbackGeneratorService', [
         _applyThresholdUpdates(feedback);
         previousRuntimeErrorString = codeEvalResult.getErrorString();
 
-        // Use RegEx to find if user has print statements and add a special
-        // feedback warning explaining we don't support print statements.
-        var code = codeEvalResult.getPreprocessedCode();
-        if (_hasPrintStatement(code)) {
-          feedback = _prependPrintFeedback(feedback);
-        }
-
         return feedback;
       },
       /**
        * Returns the Feedback object for the given syntax error string.
        *
+       * @param {Array} tipParagraphs A list of FeedbackParagraph objects
+       *   representing tips to include in the feedback.
        * @param {string} errorString
        * @returns {Feedback}
        */
-      getSyntaxErrorFeedback: function(errorString) {
+      getSyntaxErrorFeedback: function(tipParagraphs, errorString) {
         // If the user receives another syntax error, increment the
         // language unfamiliarity error counter.
         _updateCounters(ERROR_COUNTER_LANGUAGE_UNFAMILIARITY);
         previousRuntimeErrorString = '';
         var feedback = FeedbackObjectFactory.create(
           FEEDBACK_CATEGORIES.SYNTAX_ERROR);
+        feedback.setTipParagraphs(tipParagraphs);
         feedback.appendSyntaxErrorParagraph(errorString);
 
         _applyThresholdUpdates(feedback);
@@ -748,9 +717,7 @@ tie.factory('FeedbackGeneratorService', [
       _getRuntimeErrorFeedback: _getRuntimeErrorFeedback,
       _getHumanReadableRuntimeFeedback: _getHumanReadableRuntimeFeedback,
       _getTimeoutErrorFeedback: _getTimeoutErrorFeedback,
-      _hasPrintStatement: _hasPrintStatement,
       _jsToHumanReadable: _jsToHumanReadable,
-      _prependPrintFeedback: _prependPrintFeedback,
       _resetCounters: _resetCounters,
       _updateCounters: _updateCounters
     };

--- a/client/question/services/FeedbackGeneratorServiceSpec.js
+++ b/client/question/services/FeedbackGeneratorServiceSpec.js
@@ -21,7 +21,7 @@ describe('FeedbackGeneratorService', function() {
   var CodeEvalResultObjectFactory;
   var ErrorTracebackObjectFactory;
   var FeedbackGeneratorService;
-  var FeedbackObjectFactory;
+  var FeedbackParagraphObjectFactory;
   var ReinforcementObjectFactory;
   var PrereqCheckFailureObjectFactory;
   var SuiteLevelTestObjectFactory;
@@ -53,7 +53,8 @@ describe('FeedbackGeneratorService', function() {
     CodeEvalResultObjectFactory = $injector.get('CodeEvalResultObjectFactory');
     ErrorTracebackObjectFactory = $injector.get('ErrorTracebackObjectFactory');
     FeedbackGeneratorService = $injector.get('FeedbackGeneratorService');
-    FeedbackObjectFactory = $injector.get('FeedbackObjectFactory');
+    FeedbackParagraphObjectFactory = $injector.get(
+      'FeedbackParagraphObjectFactory');
     ReinforcementObjectFactory = $injector.get('ReinforcementObjectFactory');
     PrereqCheckFailureObjectFactory = $injector.get(
       'PrereqCheckFailureObjectFactory');
@@ -500,13 +501,13 @@ describe('FeedbackGeneratorService', function() {
     });
   });
 
-  describe('_getSyntaxErrorFeedback', function() {
+  describe('getSyntaxErrorFeedback', function() {
     it([
       'should return feedback if a syntax / compiler error is ',
       'found in the user\'s code'
     ].join(''), function() {
       var feedback = FeedbackGeneratorService.getSyntaxErrorFeedback(
-        'some error');
+        [], 'some error');
       expect(feedback.getFeedbackCategory()).toEqual(
         FEEDBACK_CATEGORIES.SYNTAX_ERROR);
 
@@ -525,7 +526,7 @@ describe('FeedbackGeneratorService', function() {
         'testInput');
 
       var feedback = FeedbackGeneratorService.getFeedback(
-        questionMock, codeEvalResult, []);
+        [], questionMock, codeEvalResult, []);
       expect(feedback.getFeedbackCategory()).toEqual(
         FEEDBACK_CATEGORIES.TIME_LIMIT_ERROR);
 
@@ -831,49 +832,6 @@ describe('FeedbackGeneratorService', function() {
     });
   });
 
-  describe('_hasPrintStatement', function() {
-    it('returns true if there are print statements detected', function() {
-      var code = [
-        'def myFunc(arg):',
-        '    print arg',
-        '    return arg',
-        ''
-      ].join('\n');
-      expect(FeedbackGeneratorService._hasPrintStatement(code)).toBe(true);
-    });
-
-    it('returns false if there are no print statements detected', function() {
-      var code = [
-        'def myFunc(arg):',
-        '    return arg',
-        ''
-      ].join('\n');
-      expect(FeedbackGeneratorService._hasPrintStatement(code)).toBe(false);
-    });
-  });
-
-  describe('_prependPrintFeedback', function() {
-    it('prepends print feedback to a given feedback object', function() {
-      var oldFeedback = FeedbackObjectFactory.create(
-        FEEDBACK_CATEGORIES.SYNTAX_ERROR);
-      oldFeedback.appendTextParagraph('test paragraph');
-      var feedback = FeedbackGeneratorService._prependPrintFeedback(
-        oldFeedback);
-
-      var paragraphs = feedback.getParagraphs();
-      expect(paragraphs.length).toEqual(2);
-      expect(paragraphs[0].isTextParagraph()).toBe(true);
-      expect(paragraphs[1].isTextParagraph()).toBe(true);
-      expect(paragraphs[0].getContent()).toEqual([
-        'We noticed that you\'re using a print statement within your code. ',
-        'Since you will not be able to use such statements in a technical ',
-        'interview, TIE does not support this feature. We encourage you to ',
-        'instead step through your code by hand.'
-      ].join(''));
-      expect(paragraphs[1].getContent()).toEqual('test paragraph');
-    });
-  });
-
   describe('getFeedback', function() {
     it('should correctly return feedback if the performance does not meet ' +
       'expectations', function() {
@@ -881,7 +839,7 @@ describe('FeedbackGeneratorService', function() {
         'some code', 'some output', [], [], ['not linear'], null, null);
 
       var feedback = FeedbackGeneratorService.getFeedback(
-        testTask, codeEvalResult, []);
+        [], testTask, codeEvalResult, []);
 
       var paragraphs = feedback.getParagraphs();
       expect(paragraphs.length).toEqual(1);
@@ -932,7 +890,8 @@ describe('FeedbackGeneratorService', function() {
       var feedback;
 
       for (var i = 0; i < UNFAMILIARITY_THRESHOLD; i++) {
-        feedback = FeedbackGeneratorService.getSyntaxErrorFeedback(errorString);
+        feedback = FeedbackGeneratorService.getSyntaxErrorFeedback(
+          [], errorString);
       }
 
       var paragraphs = feedback.getParagraphs();
@@ -956,7 +915,7 @@ describe('FeedbackGeneratorService', function() {
 
       for (var i = 0; i <= UNFAMILIARITY_THRESHOLD; i++) {
         feedback = FeedbackGeneratorService.getFeedback(
-          testTask, codeEvalResult, [0, 1, 2, 3, 4, 5]);
+          [], testTask, codeEvalResult, [0, 1, 2, 3, 4, 5]);
         TranscriptService.recordSnapshot(null, codeEvalResult, feedback);
       }
 
@@ -975,32 +934,6 @@ describe('FeedbackGeneratorService', function() {
         FeedbackGeneratorService._getUnfamiliarLanguageFeedback(
           LANGUAGE_PYTHON));
     });
-
-    it('should correctly return feedback if print statements are detected',
-      function() {
-        var code = [
-          'def myFunction(arg):',
-          '    print arg',
-          ''
-        ].join('\n');
-
-        var codeEvalResult = CodeEvalResultObjectFactory.create(
-          code, 'output', [], [], [['not linear']], null, null);
-
-        var feedback = FeedbackGeneratorService.getFeedback(
-          testTask, codeEvalResult, []);
-
-        var paragraphs = feedback.getParagraphs();
-        expect(paragraphs.length).toEqual(2);
-        expect(paragraphs[0].isTextParagraph()).toBe(true);
-        expect(paragraphs[0].getContent()).toEqual([
-          'We noticed that you\'re using a print statement within your code. ',
-          'Since you will not be able to use such statements in a technical ',
-          'interview, TIE does not support this feature. We encourage you to ',
-          'instead step through your code by hand.'
-        ].join(''));
-      }
-    );
   });
 
   describe('getPrereqFailureFeedback', function() {
@@ -1306,6 +1239,45 @@ describe('FeedbackGeneratorService', function() {
         FeedbackGeneratorService.getPrereqFailureFeedback(prereqFailure);
       }).toThrow();
     });
+  });
+
+  describe('tips', function() {
+    it('should include tips passed in when returning feedback', function() {
+      var tip = FeedbackParagraphObjectFactory.fromDict({
+        type: 'text',
+        content: 'a tip'
+      });
+      var codeEvalResult = CodeEvalResultObjectFactory.create(
+        'some code', 'some output', [], [], ['not linear'], null, null);
+
+      var feedback = FeedbackGeneratorService.getFeedback(
+        [tip], testTask, codeEvalResult, []);
+      var paragraphs = feedback.getParagraphs();
+      expect(paragraphs.length).toEqual(2);
+      expect(paragraphs[0].isTextParagraph()).toBe(true);
+      expect(paragraphs[0].getContent()).toEqual('a tip');
+    });
+
+    it(
+      'should include tips passed in when returning syntax error feedback',
+      function() {
+        var tip = FeedbackParagraphObjectFactory.fromDict({
+          type: 'text',
+          content: 'a tip'
+        });
+        var feedback = FeedbackGeneratorService.getSyntaxErrorFeedback(
+          [tip], 'some error');
+        expect(feedback.getFeedbackCategory()).toEqual(
+          FEEDBACK_CATEGORIES.SYNTAX_ERROR);
+
+        var paragraphs = feedback.getParagraphs();
+        expect(paragraphs.length).toEqual(2);
+        expect(paragraphs[0].isTextParagraph()).toBe(true);
+        expect(paragraphs[0].getContent()).toEqual('a tip');
+        expect(paragraphs[1].isSyntaxErrorParagraph()).toBe(true);
+        expect(paragraphs[1].getContent()).toBe('some error');
+      }
+    );
   });
 });
 

--- a/client/question/services/ReinforcementGeneratorServiceSpec.js
+++ b/client/question/services/ReinforcementGeneratorServiceSpec.js
@@ -147,7 +147,7 @@ describe('ReinforcementGeneratorService', function() {
           'some code', 'some output', [[[false], [false]]],
           [], [], null, null);
         var feedback = FeedbackGeneratorService.getFeedback(
-          taskWithTwoSuites, codeEvalResult, [0, 1, 2, 3, 4]);
+          [], taskWithTwoSuites, codeEvalResult, [0, 1, 2, 3, 4]);
 
         TranscriptService.recordSnapshot(null, codeEvalResult, feedback);
 
@@ -183,7 +183,7 @@ describe('ReinforcementGeneratorService', function() {
         'some code', 'some output', [[[false], [false], [false]]],
         [], [], null, null);
       var feedback = FeedbackGeneratorService.getFeedback(
-        taskWithThreeSuites, codeEvalResult, [0, 1, 2, 3, 4]);
+        [], taskWithThreeSuites, codeEvalResult, [0, 1, 2, 3, 4]);
 
       TranscriptService.recordSnapshot(null, codeEvalResult, feedback);
 
@@ -212,7 +212,7 @@ describe('ReinforcementGeneratorService', function() {
         'some code', 'some output', [[[false], [false], [false]]],
         [], [], null, null);
       var feedback = FeedbackGeneratorService.getFeedback(
-        taskWithThreeSuites, codeEvalResult, [0, 1, 2, 3, 4]);
+        [], taskWithThreeSuites, codeEvalResult, [0, 1, 2, 3, 4]);
 
       TranscriptService.recordSnapshot(null, codeEvalResult, feedback);
       var reinforcement = ReinforcementGeneratorService.getReinforcement(
@@ -250,7 +250,7 @@ describe('ReinforcementGeneratorService', function() {
           'some code', 'some output', [[[true], [true], [true]]],
           [], [], null, null);
         var feedback = FeedbackGeneratorService.getFeedback(
-          taskWithThreeSuites, codeEvalResult, [0, 1, 2, 3, 4]);
+          [], taskWithThreeSuites, codeEvalResult, [0, 1, 2, 3, 4]);
 
         TranscriptService.recordSnapshot(null, codeEvalResult, feedback);
 
@@ -291,7 +291,7 @@ describe('ReinforcementGeneratorService', function() {
           'some code', 'some output', [[[false], [false], [false]]],
           [], [], null, null);
         var feedback = FeedbackGeneratorService.getFeedback(
-          taskWithThreeSuites, codeEvalResult, [0, 1, 2, 3, 4]);
+          [], taskWithThreeSuites, codeEvalResult, [0, 1, 2, 3, 4]);
 
         TranscriptService.recordSnapshot(null, codeEvalResult, feedback);
         var pastFailedCases = feedback.getReinforcement().getPastFailedCases();
@@ -306,7 +306,7 @@ describe('ReinforcementGeneratorService', function() {
           'some code', 'some output', [[[true], [false], [false]]],
           [], [], null, null);
         feedback = FeedbackGeneratorService.getFeedback(
-          taskWithThreeSuites, codeEvalResult2, [0, 1, 2, 3, 4]);
+          [], taskWithThreeSuites, codeEvalResult2, [0, 1, 2, 3, 4]);
         TranscriptService.recordSnapshot(null, codeEvalResult2, feedback);
 
         pastFailedCases = feedback.getReinforcement().getPastFailedCases();
@@ -322,7 +322,7 @@ describe('ReinforcementGeneratorService', function() {
           'some code', 'some output', [[[true], [true], [false]]],
           [], [], null, null);
         feedback = FeedbackGeneratorService.getFeedback(
-          taskWithThreeSuites, codeEvalResult3, [0, 1, 2, 3, 4]);
+          [], taskWithThreeSuites, codeEvalResult3, [0, 1, 2, 3, 4]);
 
         TranscriptService.recordSnapshot(null, codeEvalResult3, feedback);
 
@@ -355,7 +355,7 @@ describe('ReinforcementGeneratorService', function() {
         'some code', 'some output', [[[false, false, false]]],
         [], [], null, null);
       var feedback = FeedbackGeneratorService.getFeedback(
-        taskWithThreeCases, codeEvalResult, [0, 1, 2, 3, 4]);
+        [], taskWithThreeCases, codeEvalResult, [0, 1, 2, 3, 4]);
 
       TranscriptService.recordSnapshot(null, codeEvalResult, feedback);
       var pastFailedCases = feedback.getReinforcement().getPastFailedCases();
@@ -370,7 +370,7 @@ describe('ReinforcementGeneratorService', function() {
         'some code', 'some output', [[[true, false, false]]],
         [], [], null, null);
       feedback = FeedbackGeneratorService.getFeedback(
-        taskWithThreeCases, codeEvalResult2, [0, 1, 2, 3, 4]);
+        [], taskWithThreeCases, codeEvalResult2, [0, 1, 2, 3, 4]);
 
       TranscriptService.recordSnapshot(null, codeEvalResult2, feedback);
 
@@ -387,7 +387,7 @@ describe('ReinforcementGeneratorService', function() {
         'some code', 'some output', [[[true, true, false]]],
         [], [], null, null);
       feedback = FeedbackGeneratorService.getFeedback(
-        taskWithThreeCases, codeEvalResult3, [0, 1, 2, 3, 4]);
+        [], taskWithThreeCases, codeEvalResult3, [0, 1, 2, 3, 4]);
 
       TranscriptService.recordSnapshot(null, codeEvalResult3, feedback);
 

--- a/client/question/services/SolutionHandlerService.js
+++ b/client/question/services/SolutionHandlerService.js
@@ -20,11 +20,11 @@
 tie.factory('SolutionHandlerService', [
   '$q', 'CodePreprocessorDispatcherService', 'CodeRunnerDispatcherService',
   'FeedbackGeneratorService', 'PrereqCheckDispatcherService',
-  'TranscriptService', 'CodeSubmissionObjectFactory',
+  'TranscriptService', 'CodeSubmissionObjectFactory', 'TipsGeneratorService',
   function(
       $q, CodePreprocessorDispatcherService, CodeRunnerDispatcherService,
       FeedbackGeneratorService, PrereqCheckDispatcherService,
-      TranscriptService, CodeSubmissionObjectFactory) {
+      TranscriptService, CodeSubmissionObjectFactory, TipsGeneratorService) {
     return {
       /**
        * Asynchronously returns a Promise with a Feedback object associated
@@ -59,10 +59,13 @@ tie.factory('SolutionHandlerService', [
           return CodeRunnerDispatcherService.compileCodeAsync(
             language, studentCode
           ).then(function(codeEvalResult) {
+            var tipParagraphs = TipsGeneratorService.getTipParagraphs(
+              language, studentCode);
+
             var potentialSyntaxErrorString = codeEvalResult.getErrorString();
             if (potentialSyntaxErrorString) {
               feedback = FeedbackGeneratorService.getSyntaxErrorFeedback(
-                potentialSyntaxErrorString);
+                tipParagraphs, potentialSyntaxErrorString);
               TranscriptService.recordSnapshot(null, codeEvalResult, feedback);
               return feedback;
             }
@@ -79,7 +82,7 @@ tie.factory('SolutionHandlerService', [
               language, codeSubmission.getPreprocessedCode()
             ).then(function(preprocessedCodeEvalResult) {
               feedback = FeedbackGeneratorService.getFeedback(
-                tasks, preprocessedCodeEvalResult,
+                tipParagraphs, tasks, preprocessedCodeEvalResult,
                 codeSubmission.getRawCodeLineIndexes());
               TranscriptService.recordSnapshot(
                 null, preprocessedCodeEvalResult, feedback);

--- a/client/question/services/SolutionHandlerServiceSpec.js
+++ b/client/question/services/SolutionHandlerServiceSpec.js
@@ -547,5 +547,34 @@ describe('SolutionHandlerService', function() {
       });
     });
 
+    describe('tips', function() {
+      it('should return tips if they are triggered', function(done) {
+        orderedTasks = taskDict.map(function(task) {
+          return TaskObjectFactory.create(task);
+        });
+
+        var studentCode = [
+          'def mockMainFunction(input):',
+          '    print input',
+          '    return True',
+          ''
+        ].join('\n');
+
+        SolutionHandlerService.processSolutionAsync(
+          orderedTasks, starterCode, studentCode, auxiliaryCode, 'python'
+        ).then(function(feedback) {
+          var paragraphs = feedback.getParagraphs();
+          expect(paragraphs.length).toEqual(2);
+          expect(paragraphs[0].isTextParagraph()).toBe(true);
+          expect(paragraphs[0].getContent()).toEqual([
+            'We noticed that you\'re using a print statement within your ',
+            'code. Since you will not be able to use such statements in a ',
+            'technical interview, TIE does not support this feature. We ',
+            'encourage you to instead step through your code by hand.'
+          ].join(''));
+          done();
+        });
+      });
+    });
   });
 });

--- a/client/question/services/TipsGeneratorService.js
+++ b/client/question/services/TipsGeneratorService.js
@@ -1,0 +1,72 @@
+// Copyright 2017 The TIE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service for generating tips based on a user's code submission.
+ */
+
+tie.factory('TipsGeneratorService', [
+  'SYSTEM_GENERATED_TIPS', 'PrereqCheckDispatcherService',
+  'FeedbackParagraphObjectFactory',
+  function(
+      SYSTEM_GENERATED_TIPS, PrereqCheckDispatcherService,
+      FeedbackParagraphObjectFactory) {
+    /**
+     * Returns a list of paragraphs indicating system-generated tips for the
+     * learner.
+     *
+     * @param {string} language The language in which the code is written.
+     * @param {string} code The code to analyze.
+     * @returns {Array} A list of FeedbackParagraph objects, representing
+     *   system-generated tips, to prepend to the regular TIE feedback.
+     */
+    var getSystemTipParagraphs = function(language, codeLines) {
+      var tipParagraphs = [];
+
+      SYSTEM_GENERATED_TIPS[language].forEach(function(tipSpecification) {
+        var regexp = new RegExp(tipSpecification.regExString);
+        var detected = codeLines.some(function(line) {
+          return line.search(regexp) !== -1;
+        });
+        if (detected) {
+          var feedbackParagraphs = tipSpecification.feedbackParagraphs.map(
+            function(paragraphDict) {
+              return FeedbackParagraphObjectFactory.fromDict(paragraphDict);
+            });
+          tipParagraphs = tipParagraphs.concat(feedbackParagraphs);
+        }
+      });
+
+      return tipParagraphs;
+    };
+
+    return {
+      /**
+       * Returns a list of paragraphs indicating tips for the learner. System
+       * tips (e.g. print statements) are always shown, and in addition we also
+       * show at most one task-specific wrong-approach tip.
+       *
+       * @param {string} language The language in which the code is written.
+       * @param {string} code The code to analyze.
+       * @returns {Array} A list of FeedbackParagraph objects to prepend to the
+       *   regular TIE feedback.
+       */
+      getTipParagraphs: function(language, code) {
+        var codeLines = PrereqCheckDispatcherService.getNonStringLines(
+          language, code);
+        return getSystemTipParagraphs(language, codeLines);
+      }
+    };
+  }
+]);

--- a/client/question/services/TipsGeneratorServiceSpec.js
+++ b/client/question/services/TipsGeneratorServiceSpec.js
@@ -1,0 +1,53 @@
+// Copyright 2017 The TIE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for TipsGeneratorService.
+ */
+
+describe('TipsGeneratorService', function() {
+  var LANGUAGE_PYTHON;
+  var TipsGeneratorService;
+  var FeedbackParagraphObjectFactory;
+
+  beforeEach(module('tie'));
+  beforeEach(inject(function($injector) {
+    LANGUAGE_PYTHON = $injector.get('LANGUAGE_PYTHON');
+    TipsGeneratorService = $injector.get('TipsGeneratorService');
+    FeedbackParagraphObjectFactory = $injector.get(
+      'FeedbackParagraphObjectFactory');
+  }));
+
+  describe('getTipParagraphs', function() {
+    it('returns a tip to avoid the print statement, where needed', function() {
+      var tipParagraphs = TipsGeneratorService.getTipParagraphs(
+        LANGUAGE_PYTHON, [
+          'def func(a):',
+          '    print a',
+          ''
+        ].join(''));
+
+      expect(tipParagraphs.length).toBe(1);
+      var tipParagraph = tipParagraphs[0];
+      expect(tipParagraph instanceof FeedbackParagraphObjectFactory).toBe(true);
+      expect(tipParagraph.isTextParagraph()).toBe(true);
+      expect(tipParagraph.getContent()).toEqual([
+        'We noticed that you\'re using a print statement within your code. ',
+        'Since you will not be able to use such statements in a technical ',
+        'interview, TIE does not support this feature. We encourage you to ',
+        'instead step through your code by hand.'
+      ].join(''));
+    });
+  });
+});

--- a/client/question/services/code_evaluators/PrereqCheckDispatcherService.js
+++ b/client/question/services/code_evaluators/PrereqCheckDispatcherService.js
@@ -37,6 +37,22 @@ tie.factory('PrereqCheckDispatcherService', [
         } else {
           throw Error('Language not supported: ' + language);
         }
+      },
+      /**
+       * Returns a list of lines that do not contain strings, in order to
+       * prevent spurious false positives in code-analysis checks.
+       *
+       * @param {string} language The language in which the code is written.
+       * @param {string} code The code to analyze.
+       * @returns {Array} A list of lines of the original code. Lines
+       *   containing strings are omitted.
+       */
+      getNonStringLines: function(language, code) {
+        if (language === LANGUAGE_PYTHON) {
+          return PythonPrereqCheckService.getNonStringLines(code);
+        } else {
+          throw Error('Language not supported: ' + language);
+        }
       }
     };
   }

--- a/client/question/services/code_evaluators/PythonPrereqCheckService.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckService.js
@@ -38,6 +38,7 @@ tie.factory('PythonPrereqCheckService', [
      *
      * NOTE TO DEVELOPERS: This check assumes that the code does not contain
      * any multi-line strings ("""....""").
+     * TODO(sll): Handle the case of multi-line strings.
      *
      * @param {string} language The language in which the code is written.
      * @param {string} code The code to analyze.

--- a/client/question/services/code_evaluators/PythonPrereqCheckService.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckService.js
@@ -31,23 +31,36 @@ tie.factory('PythonPrereqCheckService', [
       WRONG_LANGUAGE_ERRORS, PREREQ_CHECK_TYPE_INVALID_SYSTEM_CALL,
       PREREQ_CHECK_TYPE_INVALID_AUXILIARYCODE_CALL, CLASS_NAME_AUXILIARY_CODE,
       CLASS_NAME_SYSTEM_CODE) {
+
+    /**
+     * Returns a list of lines in the code that do not contain strings, in
+     * order to prevent spurious false positives in code-analysis checks.
+     *
+     * NOTE TO DEVELOPERS: This check assumes that the code does not contain
+     * any multi-line strings ("""....""").
+     *
+     * @param {string} language The language in which the code is written.
+     * @param {string} code The code to analyze.
+     * @returns {Array} A list of lines of the original code. Lines
+     *   containing strings are omitted.
+     */
+    var getNonStringLines = function(code) {
+      return code.split('\n').filter(function(codeLine) {
+        return (codeLine.indexOf('"') === -1 && codeLine.indexOf("'") === -1);
+      });
+    };
+
     /**
      * Checks if the given code uses any syntax that isn't valid in Python
      * but is specific to languages like C/C++ and Java.
      *
-     * NOTE TO DEVELOPERS: For safety, we do not process any lines that contain
-     * strings in this check. The check also assumes that the code does not
-     * contain any multi-line strings ("""....""").
-     *
-     * @param {string}
+     * @param {string} code
      * @returns {string | null} If there is wrong language syntax detected,
      *    will return the name of the error as referenced in
      *    WRONG_LANGUAGE_ERRORS.
      */
     var detectAndGetWrongLanguageType = function(code) {
-      var codeLines = code.split('\n').filter(function(codeLine) {
-        return (codeLine.indexOf('"') === -1 && codeLine.indexOf("'") === -1);
-      });
+      var codeLines = getNonStringLines(code);
 
       for (var i = 0; i < WRONG_LANGUAGE_ERRORS.python.length; i++) {
         var error = WRONG_LANGUAGE_ERRORS.python[i];
@@ -267,6 +280,7 @@ tie.factory('PythonPrereqCheckService', [
       doTopLevelFunctionLinesExist: doTopLevelFunctionLinesExist,
       extractTopLevelFunctionLines: extractTopLevelFunctionLines,
       getImportedLibraries: getImportedLibraries,
+      getNonStringLines: getNonStringLines,
       getUnsupportedImports: getUnsupportedImports,
       hasInvalidAuxiliaryClassCalls: hasInvalidAuxiliaryClassCalls,
       hasInvalidSystemClassCalls: hasInvalidSystemClassCalls

--- a/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -172,6 +172,20 @@ describe('PythonPrereqCheckService', function() {
     });
   });
 
+  describe('getNonStringLines', function() {
+    it('omits lines with string constants', function() {
+      var code = [
+        'def myFunction(arg):',
+        '    b = "hello"',
+        '    c = \'hi\'',
+        '    return arg',
+        ''
+      ].join('\n');
+      var codeLines = PythonPrereqCheckService.getNonStringLines(code);
+      expect(codeLines).toEqual(['def myFunction(arg):', '    return arg', '']);
+    });
+  });
+
   describe('getUnsupportedImports', function() {
     it('correctly returns a list of the unsupported imports', function() {
       var code = [


### PR DESCRIPTION
This is the first of a series of PRs dedicated to tips, i.e. non-blocking feedback that is shown above the regular feedback TIE provides.

This PR lays the groundwork for a tips framework, and converts the "you're using a print statement" warning into a system-generated tip. Subsequent PRs will add functionality for question-specific tips (previously known as "wrong-approach errors"), and introduce a graduated system for not showing tips after they have been ignored.

The PR also refactors the functionality for ignoring lines of code containing strings (cf. #413) into a common place, since that functionality is needed by both tips and prerequisite checks.

/cc @rabidbit 