### PR TITLE
Add task-specific tips to the feedback flow.

### DIFF
--- a/client/question/domain/CodeEvalResultObjectFactory.js
+++ b/client/question/domain/CodeEvalResultObjectFactory.js
@@ -135,6 +135,45 @@ tie.factory('CodeEvalResultObjectFactory', [
     };
 
     /**
+     * Compares the observed outputs to the expected values of the test cases,
+     * and returns the index of the first task with at least one failing test
+     * case.
+     *
+     * @returns {number|null} The index of the first task that failed, or null
+     * if all tasks passed.
+     */
+    CodeEvalResult.prototype.getIndexOfFirstFailedTask = function(tasks) {
+      if (this._observedOutputs.length === 0) {
+        // This can occur if there is a runtime or infinite-loop error.
+        return 0;
+      }
+
+      for (var i = 0; i < tasks.length; i++) {
+        var taskPassed = true;
+        var testSuites = tasks[i].getTestSuites();
+        for (var j = 0; j < testSuites.length; j++) {
+          var suitePassed = true;
+          var testCases = testSuites[j].getTestCases();
+          for (var k = 0; k < testCases.length; k++) {
+            if (!testCases[k].matchesOutput(this._observedOutputs[i][j][k])) {
+              suitePassed = false;
+              break;
+            }
+          }
+          if (!suitePassed) {
+            taskPassed = false;
+            break;
+          }
+        }
+        if (!taskPassed) {
+          return i;
+        }
+      }
+
+      return null;
+    };
+
+    /**
      * Returns the observed outputs for the last task that is run. The function
      * should return the last subarray in _observedOutputs.
      *

--- a/client/question/domain/CodeEvalResultObjectFactory.js
+++ b/client/question/domain/CodeEvalResultObjectFactory.js
@@ -139,6 +139,7 @@ tie.factory('CodeEvalResultObjectFactory', [
      * and returns the index of the first task with at least one failing test
      * case.
      *
+     * @param {Array<Task>} The list of tasks for the current question.
      * @returns {number|null} The index of the first task that failed, or null
      * if all tasks passed.
      */

--- a/client/question/domain/CodeEvalResultObjectFactorySpec.js
+++ b/client/question/domain/CodeEvalResultObjectFactorySpec.js
@@ -18,6 +18,8 @@
 
 describe('CodeEvalResultObjectFactory', function() {
   var CodeEvalResultObjectFactory;
+  var TaskObjectFactory;
+
   var codeEvalResult;
   var CODE = 'code';
   var OUTPUT = '';
@@ -31,6 +33,7 @@ describe('CodeEvalResultObjectFactory', function() {
   beforeEach(inject(function($injector) {
     CodeEvalResultObjectFactory = $injector.get(
       'CodeEvalResultObjectFactory');
+    TaskObjectFactory = $injector.get('TaskObjectFactory');
     codeEvalResult = CodeEvalResultObjectFactory.create(CODE, OUTPUT,
       OBSERVED_OUTPUTS, BUGGY_OUTPUT_TEST_RESULTS,
       PERFORMANCE_TEST_RESULTS, ERROR_STRING, ERROR_INPUT);
@@ -58,7 +61,6 @@ describe('CodeEvalResultObjectFactory', function() {
     });
   });
 
-
   describe('getOutput', function() {
     it('should correctly get output', function() {
       expect(codeEvalResult.getOutput()).toMatch(OUTPUT);
@@ -69,6 +71,97 @@ describe('CodeEvalResultObjectFactory', function() {
     it('should correctly get the observed outputs', function() {
       expect(codeEvalResult.getObservedOutputs())
         .toEqual(OBSERVED_OUTPUTS);
+    });
+  });
+
+  describe('getIndexOfFirstFailedTask', function() {
+    it('should correctly get the index of the first failed task', function() {
+      var tasks = [
+        TaskObjectFactory.create({
+          instructions: [''],
+          prerequisiteSkills: [''],
+          acquiredSkills: [''],
+          inputFunctionName: null,
+          outputFunctionName: null,
+          mainFunctionName: 'mockMainFunction',
+          languageSpecificTips: {
+            python: []
+          },
+          testSuites: [{
+            id: 'GENERAL_CASE',
+            humanReadableName: 'the general case',
+            testCases: [{
+              input: 'task_1_correctness_test_1',
+              allowedOutputs: [true]
+            }, {
+              input: 'task_1_correctness_test_2',
+              allowedOutputs: [true]
+            }]
+          }],
+          buggyOutputTests: [],
+          suiteLevelTests: [],
+          performanceTests: []
+        }),
+        TaskObjectFactory.create({
+          instructions: [''],
+          prerequisiteSkills: [''],
+          acquiredSkills: [''],
+          inputFunctionName: null,
+          outputFunctionName: null,
+          mainFunctionName: 'mockMainFunction',
+          languageSpecificTips: {
+            python: []
+          },
+          testSuites: [{
+            id: 'GENERAL_CASE',
+            humanReadableName: 'the general case',
+            testCases: [{
+              input: 'task_2_correctness_test_1',
+              allowedOutputs: [true]
+            }, {
+              input: 'task_2_correctness_test_2',
+              allowedOutputs: [true]
+            }]
+          }],
+          buggyOutputTests: [],
+          suiteLevelTests: [],
+          performanceTests: []
+        })
+      ];
+
+      var codeEvalResult1 = CodeEvalResultObjectFactory.create(
+        CODE, OUTPUT, [[[true, true]], [[true, true]]],
+        BUGGY_OUTPUT_TEST_RESULTS, PERFORMANCE_TEST_RESULTS, ERROR_STRING,
+        ERROR_INPUT);
+      expect(codeEvalResult1.getIndexOfFirstFailedTask(tasks))
+        .toEqual(null);
+
+      var codeEvalResult2 = CodeEvalResultObjectFactory.create(
+        CODE, OUTPUT, [[[true, false]], [[true, true]]],
+        BUGGY_OUTPUT_TEST_RESULTS, PERFORMANCE_TEST_RESULTS, ERROR_STRING,
+        ERROR_INPUT);
+      expect(codeEvalResult2.getIndexOfFirstFailedTask(tasks))
+        .toEqual(0);
+
+      var codeEvalResult3 = CodeEvalResultObjectFactory.create(
+        CODE, OUTPUT, [[[true, true]], [[false, true]]],
+        BUGGY_OUTPUT_TEST_RESULTS, PERFORMANCE_TEST_RESULTS, ERROR_STRING,
+        ERROR_INPUT);
+      expect(codeEvalResult3.getIndexOfFirstFailedTask(tasks))
+        .toEqual(1);
+
+      var codeEvalResult4 = CodeEvalResultObjectFactory.create(
+        CODE, OUTPUT, [[[true, false]], [[false, true]]],
+        BUGGY_OUTPUT_TEST_RESULTS, PERFORMANCE_TEST_RESULTS, ERROR_STRING,
+        ERROR_INPUT);
+      expect(codeEvalResult4.getIndexOfFirstFailedTask(tasks))
+        .toEqual(0);
+
+      var codeEvalResult5 = CodeEvalResultObjectFactory.create(
+        CODE, OUTPUT, [], BUGGY_OUTPUT_TEST_RESULTS, PERFORMANCE_TEST_RESULTS,
+        ERROR_STRING, ERROR_INPUT);
+      expect(codeEvalResult5.getIndexOfFirstFailedTask(tasks))
+        .toEqual(0);
     });
   });
 

--- a/client/question/services/SolutionHandlerService.js
+++ b/client/question/services/SolutionHandlerService.js
@@ -25,6 +25,27 @@ tie.factory('SolutionHandlerService', [
       $q, CodePreprocessorDispatcherService, CodeRunnerDispatcherService,
       FeedbackGeneratorService, PrereqCheckDispatcherService,
       TranscriptService, CodeSubmissionObjectFactory, TipsGeneratorService) {
+    // Caches the index of the first failed task in the most recent submission
+    // that passes syntax checks. This is initialized to zero because, at the
+    // outset (before the user even submits any code), none of the tasks are
+    // passing.
+    var indexOfFirstFailedTask = 0;
+
+    /**
+     * Returns the list of tips for the given index, or an empty array if the
+     * given index is null.
+     *
+     * @param {Array<Task>} tasks The list of tasks
+     * @param {string} language The language the user's code is written in
+     * @param {number|null} taskIndexOrNull The index of a task, or null.
+     * @returns {Array<Tip>} tips The corresponding array of Tip objects.
+     */
+    var getTips = function(tasks, language, taskIndexOrNull) {
+      return (
+        (taskIndexOrNull === null) ? [] :
+        tasks[taskIndexOrNull].getTips(language));
+    };
+
     return {
       /**
        * Asynchronously returns a Promise with a Feedback object associated
@@ -59,13 +80,13 @@ tie.factory('SolutionHandlerService', [
           return CodeRunnerDispatcherService.compileCodeAsync(
             language, studentCode
           ).then(function(codeEvalResult) {
-            var tipParagraphs = TipsGeneratorService.getTipParagraphs(
-              language, studentCode);
-
             var potentialSyntaxErrorString = codeEvalResult.getErrorString();
             if (potentialSyntaxErrorString) {
+              var previousTipParagraphs = TipsGeneratorService.getTipParagraphs(
+                language, studentCode,
+                getTips(tasks, language, indexOfFirstFailedTask));
               feedback = FeedbackGeneratorService.getSyntaxErrorFeedback(
-                tipParagraphs, potentialSyntaxErrorString);
+                previousTipParagraphs, potentialSyntaxErrorString);
               TranscriptService.recordSnapshot(null, codeEvalResult, feedback);
               return feedback;
             }
@@ -81,6 +102,11 @@ tie.factory('SolutionHandlerService', [
             return CodeRunnerDispatcherService.runCodeAsync(
               language, codeSubmission.getPreprocessedCode()
             ).then(function(preprocessedCodeEvalResult) {
+              indexOfFirstFailedTask = (
+                preprocessedCodeEvalResult.getIndexOfFirstFailedTask(tasks));
+              var tipParagraphs = TipsGeneratorService.getTipParagraphs(
+                language, studentCode,
+                getTips(tasks, language, indexOfFirstFailedTask));
               feedback = FeedbackGeneratorService.getFeedback(
                 tipParagraphs, tasks, preprocessedCodeEvalResult,
                 codeSubmission.getRawCodeLineIndexes());

--- a/client/question/services/SolutionHandlerServiceSpec.js
+++ b/client/question/services/SolutionHandlerServiceSpec.js
@@ -32,6 +32,9 @@ describe('SolutionHandlerService', function() {
     inputFunctionName: null,
     outputFunctionName: null,
     mainFunctionName: 'mockMainFunction',
+    languageSpecificTips: {
+      python: []
+    },
     testSuites: [{
       id: 'GENERAL_CASE',
       humanReadableName: 'the general case',
@@ -66,6 +69,9 @@ describe('SolutionHandlerService', function() {
     inputFunctionName: null,
     outputFunctionName: null,
     mainFunctionName: 'mockMainFunction',
+    languageSpecificTips: {
+      python: []
+    },
     testSuites: [{
       id: 'GENERAL_CASE',
       humanReadableName: 'the general case',

--- a/client/question/services/TipsGeneratorService.js
+++ b/client/question/services/TipsGeneratorService.js
@@ -27,7 +27,7 @@ tie.factory('TipsGeneratorService', [
      * learner. At most one system-generated tip is presented.
      *
      * @param {string} language The language in which the code is written.
-     * @param {string} codeLines The lines of code to analyze.
+     * @param {Array<string>} codeLines The lines of code to analyze.
      * @returns {Array<FeedbackParagraph>} The feedback paragraphs to prepend
      *   to the regular TIE feedback.
      */
@@ -55,7 +55,7 @@ tie.factory('TipsGeneratorService', [
      *
      * @param {Array<Tip>} taskSpecificTips The checks to apply for determining
      *  which task-specific tips to show.
-     * @param {string} codeLines The lines of code to analyze.
+     * @param {Array<string>} codeLines The lines of code to analyze.
      * @returns {Array<FeedbackParagraph>} The feedback paragraphs to prepend
      *   to the general feedback. At most one task-specific tip is prepended
      *   (to avoid cognitive overload).

--- a/client/question/services/TipsGeneratorService.js
+++ b/client/question/services/TipsGeneratorService.js
@@ -69,7 +69,7 @@ tie.factory('TipsGeneratorService', [
         });
         if (detected) {
           return [FeedbackParagraphObjectFactory.createTextParagraph(
-            'Tip: ' + tipSpecification.getMessage())];
+            tipSpecification.getMessage())];
         }
       }
 

--- a/client/question/services/TipsGeneratorServiceSpec.js
+++ b/client/question/services/TipsGeneratorServiceSpec.js
@@ -20,6 +20,7 @@ describe('TipsGeneratorService', function() {
   var LANGUAGE_PYTHON;
   var TipsGeneratorService;
   var FeedbackParagraphObjectFactory;
+  var tips;
 
   beforeEach(module('tie'));
   beforeEach(inject(function($injector) {
@@ -27,10 +28,22 @@ describe('TipsGeneratorService', function() {
     TipsGeneratorService = $injector.get('TipsGeneratorService');
     FeedbackParagraphObjectFactory = $injector.get(
       'FeedbackParagraphObjectFactory');
+
+    var TipObjectFactory = $injector.get('TipObjectFactory');
+    tips = [
+      TipObjectFactory.create({
+        regexString: 'abc',
+        message: 'Tip abc triggered'
+      }),
+      TipObjectFactory.create({
+        regexString: 'xyz',
+        message: 'Tip xyz triggered'
+      })
+    ];
   }));
 
   describe('getTipParagraphs', function() {
-    it('returns a tip to avoid the print statement, where needed', function() {
+    it('returns a system tip to avoid the print statement', function() {
       var tipParagraphs = TipsGeneratorService.getTipParagraphs(
         LANGUAGE_PYTHON, [
           'def func(a):',
@@ -48,6 +61,76 @@ describe('TipsGeneratorService', function() {
         'Since you will not be able to use such statements in a technical ',
         'interview, TIE does not support this feature. We encourage you to ',
         'instead step through your code by hand.'
+      ].join(''));
+    });
+
+    it('returns a question-specific tip if one is available', function() {
+      var tipParagraphs = TipsGeneratorService.getTipParagraphs(
+        LANGUAGE_PYTHON, [
+          'def func(a):',
+          '    abc = a',
+          ''
+        ].join(''),
+        tips);
+
+      expect(tipParagraphs.length).toBe(1);
+      var tipParagraph = tipParagraphs[0];
+      expect(tipParagraph instanceof FeedbackParagraphObjectFactory).toBe(true);
+      expect(tipParagraph.isTextParagraph()).toBe(true);
+      expect(tipParagraph.getContent()).toEqual([
+        'Tip abc triggered'
+      ].join(''));
+    });
+
+    it('returns at most one question-specific tip', function() {
+      var tipParagraphs = TipsGeneratorService.getTipParagraphs(
+        LANGUAGE_PYTHON, [
+          'def func(a):',
+          '    abc = a',
+          '    xyz = abc',
+          '    return abc',
+          ''
+        ].join(''),
+        tips);
+
+      expect(tipParagraphs.length).toBe(1);
+      var tipParagraph = tipParagraphs[0];
+      expect(tipParagraph instanceof FeedbackParagraphObjectFactory).toBe(true);
+      expect(tipParagraph.isTextParagraph()).toBe(true);
+      expect(tipParagraph.getContent()).toEqual([
+        'Tip abc triggered'
+      ].join(''));
+    });
+
+    it('returns both the system and question-specific tips', function() {
+      var tipParagraphs = TipsGeneratorService.getTipParagraphs(
+        LANGUAGE_PYTHON, [
+          'def func(a):',
+          '    abc = a',
+          '    print a',
+          ''
+        ].join(''),
+        tips);
+
+      expect(tipParagraphs.length).toBe(2);
+
+      var tipParagraph1 = tipParagraphs[0];
+      expect(tipParagraph1 instanceof FeedbackParagraphObjectFactory)
+        .toBe(true);
+      expect(tipParagraph1.isTextParagraph()).toBe(true);
+      expect(tipParagraph1.getContent()).toEqual([
+        'We noticed that you\'re using a print statement within your code. ',
+        'Since you will not be able to use such statements in a technical ',
+        'interview, TIE does not support this feature. We encourage you to ',
+        'instead step through your code by hand.'
+      ].join(''));
+
+      var tipParagraph2 = tipParagraphs[1];
+      expect(tipParagraph2 instanceof FeedbackParagraphObjectFactory).toBe(
+        true);
+      expect(tipParagraph2.isTextParagraph()).toBe(true);
+      expect(tipParagraph2.getContent()).toEqual([
+        'Tip abc triggered'
       ].join(''));
     });
   });

--- a/client/question/services/TipsGeneratorServiceSpec.js
+++ b/client/question/services/TipsGeneratorServiceSpec.js
@@ -36,7 +36,8 @@ describe('TipsGeneratorService', function() {
           'def func(a):',
           '    print a',
           ''
-        ].join(''));
+        ].join(''),
+        []);
 
       expect(tipParagraphs.length).toBe(1);
       var tipParagraph = tipParagraphs[0];


### PR DESCRIPTION
This PR adds task-specific tips (e.g. "you don't need regexes for this question") to the feedback flow. I still need to add tests for:

- CodeEvalResult.prototype.getIndexOfFirstFailedTask
- TipsGeneratorService.getTipParagraphs() to account for question-specific tips

and, in a future PR, make changes to show a given tip at most twice in succession (currently we show a tip whenever it applies).

In the meantime, though, @rabidbit -- could you PTAL at the code/UX? I'd like to confirm that the behavior and core ideas are correct. Thanks!