### PR TITLE
Refactor learner view to generalize the onCodeChange loop to do other things besides autosaving.

### DIFF
--- a/client/question/question.js
+++ b/client/question/question.js
@@ -733,7 +733,7 @@ tie.constant('SECONDS_TO_MILLISECONDS', 1000);
  * @type {number}
  * @constant
  */
-tie.constant('DEFAULT_AUTOSAVE_SECONDS', 5);
+tie.constant('CODE_CHANGE_DEBOUNCE_SECONDS', 5);
 
 /**
  * Default time in seconds between calls to SendEventBatch.


### PR DESCRIPTION
@eyurko PTAL -- this change preps the learner view directive to do other things besides autosaving on a code change event. This PR introduces no change in user behaviour; a subsequent PR will add functionality to show/hide unprompted feedback.

Also, /cc @rabidbit for info.