### PR TITLE
Added Reset Feedback button and separating resetting code/feedback functionality

### DIFF
--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -55,7 +55,7 @@ tie.directive('learnerView', [function() {
                 </monospace-display-modal>
               </div>
               <button class="tie-code-reset tie-button" ng-click="resetFeedback()">
-                  Reset Feedback
+                Reset Feedback
               </button>
               <select class="tie-select-menu" name="theme-select"
                   ng-change="changeTheme(theme)" ng-model="theme"
@@ -956,7 +956,7 @@ tie.directive('learnerView', [function() {
           ConversationLogDataService.clear();
           LocalStorageService.clearLocalStorageFeedback(
             $scope.currentQuestionId, language);
-        }
+        };
 
         /**
          * Displays a notification for the given number of seconds to let the

--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -54,6 +54,9 @@ tie.directive('learnerView', [function() {
                     content="content">
                 </monospace-display-modal>
               </div>
+              <button class="tie-code-reset tie-button" ng-click="resetFeedback()">
+                  Reset Feedback
+              </button>
               <select class="tie-select-menu" name="theme-select"
                   ng-change="changeTheme(theme)" ng-model="theme"
                   ng-options="i.themeName as i.themeName for i in themes">
@@ -135,7 +138,7 @@ tie.directive('learnerView', [function() {
           height: 24px;
           margin-right: 10px;
           padding: 1px 6px;
-          width: 100px;
+          width: 104px;
         }
         .tie-button:hover {
           border: 1px solid #e4e4e4;
@@ -667,7 +670,6 @@ tie.directive('learnerView', [function() {
           $scope.title = question.getTitle();
           $scope.editorContents.code = (
             cachedCode || question.getStarterCode(language));
-          ConversationLogDataService.clear();
           var loadedFeedbackParagraphs = LocalStorageService.loadLatestFeedback(
             questionId, language);
           if (loadedFeedbackParagraphs) {
@@ -939,10 +941,22 @@ tie.directive('learnerView', [function() {
         $scope.resetCode = function() {
           LocalStorageService.clearLocalStorageCode(
             $scope.currentQuestionId, language);
+          LocalStorageService.clearLocalStorageFeedback(
+            $scope.currentQuestionId, language);
           EventHandlerService.createCodeResetEvent(
             SessionIdService.getSessionId());
           $scope.loadQuestion($scope.currentQuestionId);
         };
+
+        /**
+         * Clears the feedback in the window, and deletes the feedback
+         * from local storage for the current question.
+         */
+        $scope.resetFeedback = function() {
+          ConversationLogDataService.clear();
+          LocalStorageService.clearLocalStorageFeedback(
+            $scope.currentQuestionId, language);
+        }
 
         /**
          * Displays a notification for the given number of seconds to let the


### PR DESCRIPTION
Using Sean's suggestion, resetting either the feedback or the code will clear the LocalStorage feedback. That means that if a user resets the code, the current feedback won't be cleared but if they refresh the page, then it won't be able to fetch any feedback, and will be blank. Resetting the feedback will remove the feedback both in the feedback window and in LocalStorage.

This should fix #479, #279, and #398.