### PR TITLE
Disable button if there is feedback pending

### DIFF
--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -88,7 +88,7 @@ tie.directive('learnerView', [function() {
                   Saving code...
                 </div>
                 <button class="tie-run-button tie-button tie-button-green protractor-test-run-code-btn"
-                    ng-click="submitCode(editorContents.code)">
+                    ng-click="submitCode(editorContents.code)" ng-disabled="ConversationLogDataService.isNewBalloonPending()">
                   I think I&#39m done
                 </button>
               </div>
@@ -434,6 +434,7 @@ tie.directive('learnerView', [function() {
           ConversationLogDataService, DELAY_STYLE_CHANGES) {
 
         $scope.MonospaceDisplayModalService = MonospaceDisplayModalService;
+        $scope.ConversationLogDataService = ConversationLogDataService;
 
         /**
          * Array of strings containing the ids of the allowed question sets.

--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -433,8 +433,8 @@ tie.directive('learnerView', [function() {
           FEEDBACK_CATEGORIES, DEFAULT_EVENT_BATCH_PERIOD_SECONDS,
           ConversationLogDataService, DELAY_STYLE_CHANGES) {
 
-        $scope.MonospaceDisplayModalService = MonospaceDisplayModalService;
         $scope.ConversationLogDataService = ConversationLogDataService;
+        $scope.MonospaceDisplayModalService = MonospaceDisplayModalService;
 
         /**
          * Array of strings containing the ids of the allowed question sets.


### PR DESCRIPTION
Following discussion in #467, the button is now disabled (but not visually) to the user when there is feedback pending. I can make CSS changes to the button but it looked like @rabidbit preferred to have it basically be disabled but not visibly so.