### PR TITLE
Add final sentence to congratulatory feedback. Fix regression caused by #492.

### DIFF
--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -783,6 +783,8 @@ tie.directive('learnerView', [function() {
           congratulatoryFeedback.clear();
           congratulatoryFeedback.appendTextParagraph(
               "Good work! You've completed this question.");
+          congratulatoryFeedback.appendTextParagraph(
+              "(You can continue to submit additional answers, if you wish.)");
 
           ConversationLogDataService.addFeedbackBalloon(
             congratulatoryFeedback.getParagraphs());

--- a/client/question/components/SpeechBalloonsContainerDirective.js
+++ b/client/question/components/SpeechBalloonsContainerDirective.js
@@ -27,7 +27,7 @@ tie.directive('speechBalloonsContainer', [function() {
           <div class="tie-dot tie-dot-2"></div>
           <div class="tie-dot tie-dot-3"></div>
         </div>
-        <div ng-repeat="balloon in ConversationLogDataService.data.speechBalloonList track by $index" aria-live="assertive">
+        <div ng-repeat="balloon in ConversationLogDataService.data.speechBalloonList" aria-live="assertive">
           <tie-speech-balloon-container>
             <div ng-if="balloon.isDisplayedOnLeft()">
               <tie-speech-balloon-left>


### PR DESCRIPTION
Added final sentence to congratulatory feedback as suggested in [this comment](https://github.com/google/tie/issues/469#issuecomment-356783014).

Also fixed a regression caused by #492 that caused _all_ balloons to glow yellow when a new piece of code is submitted.