### PR TITLE
Fix #477: Reduce line height for code snippets.

### DIFF
--- a/client/question/components/CodeSnippetDirective.js
+++ b/client/question/components/CodeSnippetDirective.js
@@ -33,7 +33,7 @@ tie.directive('codeSnippet', [function() {
       <style>
         .tie-code-snippet-line {
           font-family: monospace;
-          line-height: 24px;
+          line-height: 16px;
           word-wrap: break-word;
         }
       </style>


### PR DESCRIPTION
Before and after:

![screenshot from 2018-01-10 17-24-07](https://user-images.githubusercontent.com/10575562/34803980-16d594f6-f62b-11e7-9279-a16375a16274.png)
