### PR TITLE
Remove dummy dropdown option from theme selector.

### DIFF
--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -865,11 +865,11 @@ tie.directive('learnerView', [function() {
          */
         $scope.changeTheme = function(newTheme) {
           $scope.pulseAnimationEnabled = false;
-          if (newTheme === 'Dark') {
+          if (newTheme === THEME_NAME_DARK) {
             $scope.isInDarkMode = true;
             $scope.codeMirrorOptions.theme = 'material';
           }
-          if (newTheme === 'Light') {
+          if (newTheme === THEME_NAME_LIGHT) {
             $scope.isInDarkMode = false;
             $scope.codeMirrorOptions.theme = 'default';
           }

--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -57,11 +57,13 @@ tie.directive('learnerView', [function() {
               <button class="tie-code-reset tie-button" ng-click="resetFeedback()">
                 Reset Feedback
               </button>
-              <select class="tie-select-menu" name="theme-select"
-                  ng-change="changeTheme(theme)" ng-model="theme"
-                  ng-options="i.themeName as i.themeName for i in themes">
-                <option style="display: none" value="">Theme</option>
-              </select>
+              <span>
+                <label class="tie-select-menu-label" for="themeSelector">Theme:</label>
+                <select class="tie-select-menu" id="themeSelector" name="theme-select"
+                    ng-change="changeTheme(currentThemeName)" ng-model="currentThemeName"
+                    ng-options="i.themeName as i.themeName for i in themes">
+                </select>
+              </span>
             </div>
             <div class="tie-coding-ui">
               <div class="tie-lang-terminal">
@@ -375,9 +377,19 @@ tie.directive('learnerView', [function() {
         }
         .tie-run-button {
           float: right;
-          margin-right: 0px;
+          margin-right: 0;
           margin-top: 10px;
           position: relative;
+        }
+        .tie-select-menu-label {
+          color: black;
+          float: left;
+          font-size: 13px;
+          margin-top: 10px;
+          padding: 5px;
+        }
+        .night-mode .tie-select-menu-label {
+          color: white;
         }
         .tie-select-menu {
           background-color: #ffffff;
@@ -499,15 +511,25 @@ tie.directive('learnerView', [function() {
           $scope.questionSetIds.push(dict);
         });
 
+        var THEME_NAME_LIGHT = 'Light';
+        var THEME_NAME_DARK = 'Dark';
+
         /**
          * Defines the accepted UI Themes for the editor.
          *
          * @type {Array}
          */
         $scope.themes = [
-          {themeName: 'Light'},
-          {themeName: 'Dark'}
+          {themeName: THEME_NAME_LIGHT},
+          {themeName: THEME_NAME_DARK}
         ];
+
+        /**
+         * The currently-selected theme name.
+         *
+         * @type {Object}
+         */
+        $scope.currentThemeName = THEME_NAME_LIGHT;
 
         /**
          * Defines if the code's editor is rendered in the UI.

--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -57,13 +57,10 @@ tie.directive('learnerView', [function() {
               <button class="tie-code-reset tie-button" ng-click="resetFeedback()">
                 Reset Feedback
               </button>
-              <span>
-                <label class="tie-select-menu-label" for="themeSelector">Theme:</label>
-                <select class="tie-select-menu" id="themeSelector" name="theme-select"
-                    ng-change="changeTheme(currentThemeName)" ng-model="currentThemeName"
-                    ng-options="i.themeName as i.themeName for i in themes">
-                </select>
-              </span>
+              <select class="tie-select-menu" id="themeSelector" name="theme-select"
+                  ng-change="changeTheme(currentThemeName)" ng-model="currentThemeName"
+                  ng-options="i.themeName as i.themeName for i in themes">
+              </select>
             </div>
             <div class="tie-coding-ui">
               <div class="tie-lang-terminal">
@@ -381,16 +378,6 @@ tie.directive('learnerView', [function() {
           margin-top: 10px;
           position: relative;
         }
-        .tie-select-menu-label {
-          color: black;
-          float: left;
-          font-size: 13px;
-          margin-top: 10px;
-          padding: 5px;
-        }
-        .night-mode .tie-select-menu-label {
-          color: white;
-        }
         .tie-select-menu {
           background-color: #ffffff;
           border: 1px solid transparent;
@@ -511,8 +498,8 @@ tie.directive('learnerView', [function() {
           $scope.questionSetIds.push(dict);
         });
 
-        var THEME_NAME_LIGHT = 'Light';
-        var THEME_NAME_DARK = 'Dark';
+        var THEME_NAME_LIGHT = 'Light Theme';
+        var THEME_NAME_DARK = 'Dark Theme';
 
         /**
          * Defines the accepted UI Themes for the editor.


### PR DESCRIPTION
This addresses an accessibility bug where the dropdown menu seems to have three options (but it only has two).

I followed [this approach](https://webaim.org/techniques/forms/controls#select). However, note that this entails UI changes -- see bottom of screenshot below, in particular the added "Theme:" label. Please let me know what you think -- I'm happy to make any changes.

![screenshot from 2018-02-08 13-42-32](https://user-images.githubusercontent.com/10575562/35999892-1fd3cb74-0cd6-11e8-8151-f4b7ca69a3a7.png)
