### PR TITLE
Add line numbers to PrereqCheck Obj, to display on feedback (#414)

### DIFF
--- a/client/question/domain/PrereqCheckErrorObjectFactory.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactory.js
@@ -30,7 +30,8 @@ tie.factory('PrereqCheckErrorObjectFactory', [
      *
      * @constructor
      */
-    var PrereqCheckError = function(errorName, errorLineNumber) {
+    var PrereqCheckError = function(errorName, errorLineNumber,
+      errorColumnNumber) {
       /**
        * String standing for key in WRONG_LANGUAGE_ERRORS that correlates to
        * error that triggered.
@@ -49,6 +50,14 @@ tie.factory('PrereqCheckErrorObjectFactory', [
        * @private
        */
       this._errorLineNumber = errorLineNumber;
+
+      /**
+       * Column number that correlates to error that triggered.
+       *
+       * @type {integer}
+       * @private
+       */
+      this._errorColumnNumber = errorColumnNumber;
 
       /**
        * Indicates what type of failure occurred. Defaults to the only errorType
@@ -96,14 +105,35 @@ tie.factory('PrereqCheckErrorObjectFactory', [
       this._errorLineNumber = newLineNumber;
     };
 
+    /**
+     * A getter for the _errorColumnNumber property.
+     *
+     * @returns {string}
+     */
+    PrereqCheckError.prototype.getErrorColumnNumber = function() {
+      return this._errorColumnNumber;
+    };
+
+    /**
+     * A setter for the _errorColumnNumber property.
+     *
+     * @param {integer} errorLine to set the _errorColumnNumber property to.
+     */
+    PrereqCheckError.prototype.setErrorColumnNumber = function(
+      newColumnNumber) {
+      this._errorColumnNumber = newColumnNumber;
+    };
+
     // Static class methods.
     /**
      * Returns a new PrereqCheckError object.
      *
      * @returns {PrereqCheckError}
      */
-    PrereqCheckError.create = function(errorName, errorLineNumber) {
-      return new PrereqCheckError(errorName, errorLineNumber);
+    PrereqCheckError.create = function(
+        errorName, errorLineNumber, errorColumnNumber) {
+      return new PrereqCheckError(
+        errorName, errorLineNumber, errorColumnNumber);
     };
 
     return PrereqCheckError;

--- a/client/question/domain/PrereqCheckErrorObjectFactory.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactory.js
@@ -30,8 +30,8 @@ tie.factory('PrereqCheckErrorObjectFactory', [
      *
      * @constructor
      */
-    var PrereqCheckError = function(errorName, errorLineNumber,
-      errorColumnNumber) {
+    var PrereqCheckError = function(
+      errorName, errorLineNumber, errorColumnNumber) {
       /**
        * String standing for key in WRONG_LANGUAGE_ERRORS that correlates to
        * error that triggered.

--- a/client/question/domain/PrereqCheckErrorObjectFactory.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactory.js
@@ -1,0 +1,104 @@
+// Copyright 2017 The TIE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Factory for creating a PrereqCheckError of a student's TIE
+ * session.
+ */
+
+tie.factory('PrereqCheckErrorObjectFactory', [
+  function() {
+    /**
+     * PrereqCheckError objects are used to store information related to Prereq
+     errors.
+     */
+
+    /**
+     * Constructor for PrereqCheckError.
+     *
+     * @constructor
+     */
+    var PrereqCheckError = function(errorName, errorLineNumber) {
+      /**
+       * String standing for key in WRONG_LANGUAGE_ERRORS that correlates to
+       * error that triggered.
+       * Should be null if error type is not 'wrong language.'
+       *
+       * @type {string | null}
+       * @private
+       */
+      this._errorName = errorName;
+
+      /**
+       * Line number that correlates to error that triggered.
+       * Should be null if error type does not supply a line number.
+       *
+       * @type {integer | null}
+       * @private
+       */
+      this._errorLineNumber = errorLineNumber;
+    };
+
+    /**
+     * A getter for the _errorName property.
+     *
+     * @returns {string}
+     */
+    PrereqCheckError.prototype.getErrorName = function() {
+      return this._errorName;
+    };
+
+    /**
+     * A setter for the _errorName property.
+     *
+     * @param {string} newName The key to set the _errorName property to.
+     */
+    PrereqCheckError.prototype.setErrorName = function(newName) {
+      this._errorName = newName;
+    };
+
+    /**
+     * A getter for the _errorLineNumber property.
+     *
+     * @returns {string}
+     */
+    PrereqCheckError.prototype.getErrorLineNumber = function() {
+      return (this._errorLineNumber < 0) ? null : this._errorLineNumber;
+    };
+
+    /**
+     * A setter for the _errorLineNumber property.
+     *
+     * @param {integer} errorLine to set the _errorLineNumber property to.
+     */
+    PrereqCheckError.prototype.setErrorLineNumber = function(newLineNumber) {
+      this._errorLineNumber = newLineNumber;
+    };
+
+    // Static class methods.
+    /**
+     * Returns a new PrereqCheckError object.
+     *
+     * @returns {PrereqCheckError}
+     */
+    PrereqCheckError.create = function(errorName, errorLineNumber) {
+      if (errorLineNumber < 0 && errorName === 'notOp') {
+        return null;
+      }
+      return new PrereqCheckError(errorName, errorLineNumber);
+    };
+
+    return PrereqCheckError;
+  }
+]);

--- a/client/question/domain/PrereqCheckErrorObjectFactory.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactory.js
@@ -44,9 +44,8 @@ tie.factory('PrereqCheckErrorObjectFactory', [
 
       /**
        * Line number that correlates to error that triggered.
-       * Should be null if error type does not supply a line number.
        *
-       * @type {integer | null}
+       * @type {integer}
        * @private
        */
       this._errorLineNumber = errorLineNumber;

--- a/client/question/domain/PrereqCheckErrorObjectFactory.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactory.js
@@ -18,7 +18,8 @@
  */
 
 tie.factory('PrereqCheckErrorObjectFactory', [
-  function() {
+  'PREREQ_CHECK_TYPE_WRONG_LANG',
+  function(PREREQ_CHECK_TYPE_WRONG_LANG) {
     /**
      * PrereqCheckError objects are used to store information related to Prereq
      errors.
@@ -48,6 +49,15 @@ tie.factory('PrereqCheckErrorObjectFactory', [
        * @private
        */
       this._errorLineNumber = errorLineNumber;
+
+      /**
+       * Indicates what type of failure occurred. Defaults to the only errorType
+       * currently tracked.
+       *
+       * @type {string}
+       * @private
+       */
+      this._errorType = PREREQ_CHECK_TYPE_WRONG_LANG;
     };
 
     /**
@@ -74,7 +84,7 @@ tie.factory('PrereqCheckErrorObjectFactory', [
      * @returns {string}
      */
     PrereqCheckError.prototype.getErrorLineNumber = function() {
-      return (this._errorLineNumber < 0) ? null : this._errorLineNumber;
+      return this._errorLineNumber;
     };
 
     /**
@@ -93,9 +103,6 @@ tie.factory('PrereqCheckErrorObjectFactory', [
      * @returns {PrereqCheckError}
      */
     PrereqCheckError.create = function(errorName, errorLineNumber) {
-      if (errorLineNumber < 0 && errorName === 'notOp') {
-        return null;
-      }
       return new PrereqCheckError(errorName, errorLineNumber);
     };
 

--- a/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
@@ -24,27 +24,36 @@ describe('PrereqCheckErrorObjectFactory', function() {
     PrereqCheckErrorObjectFactory = $injector.get(
       'PrereqCheckErrorObjectFactory');
   }));
-  var errorName = 'notOp';
-  var errorLineNumber = 2;
+  var error = {
+    errorName: 'notOp',
+    errorLineNumber: 2
+  };
 
   describe('create', function() {
     it('should generate an object with name and line number', function() {
-      var TestObject = {
-        _errorName: 'notOp',
-        _errorLineNumber: 2,
-        _errorType: 'wrongLang'
-      };
-      var PrereqCheckError = PrereqCheckErrorObjectFactory.create(
-        errorName, errorLineNumber);
+      var newErrorName = 'andOp';
+      var newErrorLineNumber = 35;
+      var PrereqCheckError;
+      PrereqCheckError = PrereqCheckErrorObjectFactory.create(
+        error.errorName, error.errorLineNumber);
 
-      expect(PrereqCheckError).toEqual(jasmine.objectContaining(TestObject));
+      expect(PrereqCheckError.getErrorName()).toEqual(error.errorName);
+      expect(PrereqCheckError.getErrorLineNumber()).toEqual(
+        error.errorLineNumber);
+
+      PrereqCheckError.setErrorName(newErrorName);
+      PrereqCheckError.setErrorLineNumber(newErrorLineNumber);
+
+      expect(PrereqCheckError.getErrorName()).toEqual(newErrorName);
+      expect(PrereqCheckError.getErrorLineNumber()).toEqual(newErrorLineNumber);
     });
   });
 
   describe('getErrorName', function() {
     it('should return string from error object', function() {
-      var PrereqCheckError = PrereqCheckErrorObjectFactory.create(
-        errorName, errorLineNumber);
+      var PrereqCheckError;
+      PrereqCheckError = PrereqCheckErrorObjectFactory.create(
+        error.errorName, error.errorLineNumber);
       expect(PrereqCheckError.getErrorName()).toEqual('notOp');
     });
   });

--- a/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
@@ -31,7 +31,8 @@ describe('PrereqCheckErrorObjectFactory', function() {
     it('should generate an object with name and line number', function() {
       var TestObject = {
         _errorName: 'notOp',
-        _errorLineNumber: 2
+        _errorLineNumber: 2,
+        _errorType: 'wrongLang'
       };
       var PrereqCheckError = PrereqCheckErrorObjectFactory.create(
         errorName, errorLineNumber);

--- a/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
@@ -1,0 +1,69 @@
+// Copyright 2017 The TIE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for PrereqCheckErrorObjectFactory domain objects.
+ */
+
+describe('PrereqCheckErrorObjectFactory', function() {
+  var PrereqCheckErrorObjectFactory;
+
+  beforeEach(module('tie'));
+  beforeEach(inject(function($injector) {
+    PrereqCheckErrorObjectFactory = $injector.get(
+      'PrereqCheckErrorObjectFactory');
+  }));
+  var errorName = 'notOp';
+  var errorLineNumber = 2;
+
+  describe('create', function() {
+    it('should generate an object with name and line number', function() {
+      var TestObject = {
+        _errorName: 'notOp',
+        _errorLineNumber: 2
+      };
+      var PrereqCheckError = PrereqCheckErrorObjectFactory.create(
+        errorName, errorLineNumber);
+
+      expect(PrereqCheckError).toEqual(jasmine.objectContaining(TestObject));
+    });
+  });
+
+  describe('getErrorName', function() {
+    it('should return string from error object', function() {
+      var PrereqCheckError = PrereqCheckErrorObjectFactory.create(
+        errorName, errorLineNumber);
+      expect(PrereqCheckError.getErrorName()).toEqual('notOp');
+    });
+  });
+
+  describe('nullMultilineReturn', function() {
+    var negativeErrorLineNumber = -5;
+    it('should return null if error is a multiline notOp', function() {
+      var PrereqCheckMultilineError = PrereqCheckErrorObjectFactory.create(
+      errorName, negativeErrorLineNumber);
+
+      expect(PrereqCheckMultilineError).toBeNull();
+    });
+
+    it('return name and null line number for non-notOp errors', function() {
+      errorName = 'andOp';
+      var PrereqCheckMultilineError = PrereqCheckErrorObjectFactory.create(
+      errorName, errorLineNumber);
+
+      expect(PrereqCheckMultilineError.getErrorName()).toEqual(errorName);
+      expect(PrereqCheckMultilineError.getErrorLineNumber()).toBeNull();
+    });
+  });
+});

--- a/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
@@ -47,23 +47,4 @@ describe('PrereqCheckErrorObjectFactory', function() {
       expect(PrereqCheckError.getErrorName()).toEqual('notOp');
     });
   });
-
-  describe('nullMultilineReturn', function() {
-    var negativeErrorLineNumber = -5;
-    it('should return null if error is a multiline notOp', function() {
-      var PrereqCheckMultilineError = PrereqCheckErrorObjectFactory.create(
-      errorName, negativeErrorLineNumber);
-
-      expect(PrereqCheckMultilineError).toBeNull();
-    });
-
-    it('return name and null line number for non-notOp errors', function() {
-      errorName = 'andOp';
-      var PrereqCheckMultilineError = PrereqCheckErrorObjectFactory.create(
-      errorName, negativeErrorLineNumber);
-
-      expect(PrereqCheckMultilineError.getErrorName()).toEqual(errorName);
-      expect(PrereqCheckMultilineError.getErrorLineNumber()).toBeNull();
-    });
-  });
 });

--- a/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
@@ -60,7 +60,7 @@ describe('PrereqCheckErrorObjectFactory', function() {
     it('return name and null line number for non-notOp errors', function() {
       errorName = 'andOp';
       var PrereqCheckMultilineError = PrereqCheckErrorObjectFactory.create(
-      errorName, errorLineNumber);
+      errorName, negativeErrorLineNumber);
 
       expect(PrereqCheckMultilineError.getErrorName()).toEqual(errorName);
       expect(PrereqCheckMultilineError.getErrorLineNumber()).toBeNull();

--- a/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
+++ b/client/question/domain/PrereqCheckErrorObjectFactorySpec.js
@@ -26,35 +26,67 @@ describe('PrereqCheckErrorObjectFactory', function() {
   }));
   var error = {
     errorName: 'notOp',
-    errorLineNumber: 2
+    errorLineNumber: 2,
+    errorColumnNumber: 20
   };
+  var PrereqCheckError;
 
   describe('create', function() {
-    it('should generate an object with name and line number', function() {
-      var newErrorName = 'andOp';
-      var newErrorLineNumber = 35;
-      var PrereqCheckError;
+    it('should generate an object with name, line & column number', function() {
       PrereqCheckError = PrereqCheckErrorObjectFactory.create(
-        error.errorName, error.errorLineNumber);
+        error.errorName, error.errorLineNumber, error.errorColumnNumber);
 
       expect(PrereqCheckError.getErrorName()).toEqual(error.errorName);
       expect(PrereqCheckError.getErrorLineNumber()).toEqual(
         error.errorLineNumber);
+      expect(PrereqCheckError.getErrorColumnNumber()).toEqual(
+        error.errorColumnNumber);
+    });
+
+    it('should result in a fixed errorType', function() {
+      expect(PrereqCheckError._errorType).toEqual('wrongLang');
+    });
+  });
+
+  describe('errorName', function() {
+    it('getErrorName should return string from error object', function() {
+      expect(PrereqCheckError.getErrorName()).toEqual('notOp');
+    });
+
+    it('setErrorName should update error object', function() {
+      var newErrorName = 'andOp';
 
       PrereqCheckError.setErrorName(newErrorName);
-      PrereqCheckError.setErrorLineNumber(newErrorLineNumber);
-
       expect(PrereqCheckError.getErrorName()).toEqual(newErrorName);
+    });
+  });
+
+  describe('errorLine', function() {
+    it('getErrorLine should return integer from error object', function() {
+      expect(PrereqCheckError.getErrorLineNumber()).toEqual(
+        error.errorLineNumber);
+    });
+
+    it('setErrorLine should update error object', function() {
+      var newErrorLineNumber = 35;
+
+      PrereqCheckError.setErrorLineNumber(newErrorLineNumber);
       expect(PrereqCheckError.getErrorLineNumber()).toEqual(newErrorLineNumber);
     });
   });
 
-  describe('getErrorName', function() {
-    it('should return string from error object', function() {
-      var PrereqCheckError;
-      PrereqCheckError = PrereqCheckErrorObjectFactory.create(
-        error.errorName, error.errorLineNumber);
-      expect(PrereqCheckError.getErrorName()).toEqual('notOp');
+  describe('errorColumn', function() {
+    it('getErrorLine should return integer from error object', function() {
+      expect(PrereqCheckError.getErrorColumnNumber()).toEqual(
+        error.errorColumnNumber);
+    });
+
+    it('setErrorColumn should update error object', function() {
+      var newErrorColumnNumber = 12;
+
+      PrereqCheckError.setErrorColumnNumber(newErrorColumnNumber);
+      expect(PrereqCheckError.getErrorColumnNumber()).toEqual(
+        newErrorColumnNumber);
     });
   });
 });

--- a/client/question/domain/PrereqCheckFailureObjectFactory.js
+++ b/client/question/domain/PrereqCheckFailureObjectFactory.js
@@ -51,7 +51,7 @@ tie.factory('PrereqCheckFailureObjectFactory', [
      * @constructor
      */
     var PrereqCheckFailure = function(
-        type, badImports, starterCode, wrongLangKey) {
+        type, badImports, starterCode, wrongLangKey, errorLine) {
       /**
        * Indicates what type of failure occurred.
        *
@@ -86,6 +86,15 @@ tie.factory('PrereqCheckFailureObjectFactory', [
        * @private
        */
       this._wrongLangKey = wrongLangKey;
+
+      /**
+       * Line number that correlates to error that triggered.
+       * Should be null if error type does not supply a line number
+       *
+       * @type {integer | null}
+       * @private
+       */
+      this._errorLine = errorLine;
     };
 
     // Instance methods.
@@ -243,6 +252,24 @@ tie.factory('PrereqCheckFailureObjectFactory', [
       this._wrongLangKey = newKey;
     };
 
+    /**
+     * A getter for the _errorLine property.
+     *
+     * @returns {string}
+     */
+    PrereqCheckFailure.prototype.getErrorLine = function() {
+      return this._errorLine;
+    };
+
+    /**
+     * A setter for the _errorLine property.
+     *
+     * @param {integer} errorLine to set the _errorLine property to.
+     */
+    PrereqCheckFailure.prototype.setErrorLine = function(errorLine) {
+      this._errorLine = errorLine;
+    };
+
     // Static class methods.
     /**
      * Returns a PrereqCheckFailure object with the properties given in the
@@ -259,9 +286,10 @@ tie.factory('PrereqCheckFailureObjectFactory', [
      * @returns {PrereqCheckFailure}
      */
     PrereqCheckFailure.create = function(
-        type, badImports, starterCode, wrongLangErrorName) {
+        type, badImports, starterCode, wrongLangErrorName, errorLine) {
       var errorName = wrongLangErrorName || null;
-      return new PrereqCheckFailure(type, badImports, starterCode, errorName);
+      return new PrereqCheckFailure(
+        type, badImports, starterCode, errorName, errorLine);
     };
 
     return PrereqCheckFailure;

--- a/client/question/domain/PrereqCheckFailureObjectFactory.js
+++ b/client/question/domain/PrereqCheckFailureObjectFactory.js
@@ -51,7 +51,8 @@ tie.factory('PrereqCheckFailureObjectFactory', [
      * @constructor
      */
     var PrereqCheckFailure = function(
-        type, badImports, starterCode, wrongLangKey, errorLineNumber) {
+        type, badImports, starterCode, wrongLangKey, errorLineNumber,
+        errorColumnNumber) {
       /**
        * Indicates what type of failure occurred.
        *
@@ -89,12 +90,19 @@ tie.factory('PrereqCheckFailureObjectFactory', [
 
       /**
        * Line number that correlates to error that triggered.
-       * Should be null if error type does not supply a line number.
        *
-       * @type {integer | null}
+       * @type {integer}
        * @private
        */
       this._errorLineNumber = errorLineNumber;
+
+      /**
+       * Column number that correlates to error that triggered.
+       *
+       * @type {integer}
+       * @private
+       */
+      this._errorColumnNumber = errorColumnNumber;
     };
 
     // Instance methods.
@@ -271,6 +279,27 @@ tie.factory('PrereqCheckFailureObjectFactory', [
       this._errorLineNumber = errorLineNumber;
     };
 
+
+    /**
+     * A getter for the _errorColumnNumber property.
+     *
+     * @returns {string}
+     */
+    PrereqCheckFailure.prototype.getErrorColumnNumber = function() {
+      return this._errorColumnNumber;
+    };
+
+    /**
+     * A setter for the _errorColumnNumber property.
+     *
+     * @param {integer} errorLine to set the _errorColumnNumber property to.
+     */
+    PrereqCheckFailure.prototype.setErrorColumnNumber = function(
+      newColumnNumber) {
+      this._errorColumnNumber = newColumnNumber;
+    };
+
+
     // Static class methods.
     /**
      * Returns a PrereqCheckFailure object with the properties given in the
@@ -287,10 +316,12 @@ tie.factory('PrereqCheckFailureObjectFactory', [
      * @returns {PrereqCheckFailure}
      */
     PrereqCheckFailure.create = function(
-        type, badImports, starterCode, wrongLangErrorName, errorLineNumber) {
+        type, badImports, starterCode, wrongLangErrorName, errorLineNumber,
+        errorColumnNumber) {
       var errorName = wrongLangErrorName || null;
       return new PrereqCheckFailure(
-        type, badImports, starterCode, errorName, errorLineNumber);
+        type, badImports, starterCode, errorName, errorLineNumber,
+        errorColumnNumber);
     };
 
     return PrereqCheckFailure;

--- a/client/question/domain/PrereqCheckFailureObjectFactory.js
+++ b/client/question/domain/PrereqCheckFailureObjectFactory.js
@@ -51,7 +51,7 @@ tie.factory('PrereqCheckFailureObjectFactory', [
      * @constructor
      */
     var PrereqCheckFailure = function(
-        type, badImports, starterCode, wrongLangKey, errorLine) {
+        type, badImports, starterCode, wrongLangKey, errorLineNumber) {
       /**
        * Indicates what type of failure occurred.
        *
@@ -89,12 +89,12 @@ tie.factory('PrereqCheckFailureObjectFactory', [
 
       /**
        * Line number that correlates to error that triggered.
-       * Should be null if error type does not supply a line number
+       * Should be null if error type does not supply a line number.
        *
        * @type {integer | null}
        * @private
        */
-      this._errorLine = errorLine;
+      this._errorLineNumber = errorLineNumber;
     };
 
     // Instance methods.
@@ -253,21 +253,22 @@ tie.factory('PrereqCheckFailureObjectFactory', [
     };
 
     /**
-     * A getter for the _errorLine property.
+     * A getter for the _errorLineNumber property.
      *
      * @returns {string}
      */
-    PrereqCheckFailure.prototype.getErrorLine = function() {
-      return this._errorLine;
+    PrereqCheckFailure.prototype.geterrorLineNumber = function() {
+      return this._errorLineNumber;
     };
 
     /**
-     * A setter for the _errorLine property.
+     * A setter for the _errorLineNumber property.
      *
-     * @param {integer} errorLine to set the _errorLine property to.
+     * @param {integer} errorLine to set the _errorLineNumber property to.
      */
-    PrereqCheckFailure.prototype.setErrorLine = function(errorLine) {
-      this._errorLine = errorLine;
+    PrereqCheckFailure.prototype.seterrorLineNumber = function(
+      errorLineNumber) {
+      this._errorLineNumber = errorLineNumber;
     };
 
     // Static class methods.
@@ -286,10 +287,10 @@ tie.factory('PrereqCheckFailureObjectFactory', [
      * @returns {PrereqCheckFailure}
      */
     PrereqCheckFailure.create = function(
-        type, badImports, starterCode, wrongLangErrorName, errorLine) {
+        type, badImports, starterCode, wrongLangErrorName, errorLineNumber) {
       var errorName = wrongLangErrorName || null;
       return new PrereqCheckFailure(
-        type, badImports, starterCode, errorName, errorLine);
+        type, badImports, starterCode, errorName, errorLineNumber);
     };
 
     return PrereqCheckFailure;

--- a/client/question/domain/PrereqCheckFailureObjectFactory.js
+++ b/client/question/domain/PrereqCheckFailureObjectFactory.js
@@ -257,7 +257,7 @@ tie.factory('PrereqCheckFailureObjectFactory', [
      *
      * @returns {string}
      */
-    PrereqCheckFailure.prototype.geterrorLineNumber = function() {
+    PrereqCheckFailure.prototype.getErrorLineNumber = function() {
       return this._errorLineNumber;
     };
 
@@ -266,7 +266,7 @@ tie.factory('PrereqCheckFailureObjectFactory', [
      *
      * @param {integer} errorLine to set the _errorLineNumber property to.
      */
-    PrereqCheckFailure.prototype.seterrorLineNumber = function(
+    PrereqCheckFailure.prototype.setErrorLineNumber = function(
       errorLineNumber) {
       this._errorLineNumber = errorLineNumber;
     };

--- a/client/question/question.html
+++ b/client/question/question.html
@@ -62,6 +62,7 @@
     <script src="domain/ErrorTracebackObjectFactory.js"></script>
     <script src="domain/FeedbackObjectFactory.js"></script>
     <script src="domain/FeedbackParagraphObjectFactory.js"></script>
+    <script src="domain/PrereqCheckErrorObjectFactory.js"></script>
     <script src="domain/PrereqCheckFailureObjectFactory.js"></script>
     <script src="domain/SnapshotObjectFactory.js"></script>
     <script src="domain/SpeechBalloonObjectFactory.js"></script>

--- a/client/question/services/code_evaluators/PythonPrereqCheckService.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckService.js
@@ -63,18 +63,22 @@ tie.factory('PythonPrereqCheckService', [
      * @param {string} [code] The code to convert
      * @return {string} code where all 'foo' & "bar" converted to xxxxx & xxxxx
      */
-    var obscureStringLines = function(code) {
+    var obscureStringCharacters = function(code) {
       var regexp = new RegExp(/'([^']*)'|"([^"]*)"/, 'g');
-      var matches;
-      var obscureCode;
-      var startIndex = 0;
+      var matches = [];
+      var obscureCode = '';
+      var pointer = 0;
 
       while ((matches = regexp.exec(code)) !== null) {
-        var matchLength = matches[0].length;
-        obscureCode += code.slice(startIndex, (regexp.lastIndex - matchLength));
-        obscureCode = obscureCode.padEnd(obscureCode.length + matchLength, 'x');
-        startIndex = regexp.lastIndex;
+        if (matches[0]) {
+          var matchLength = matches[0].length;
+          obscureCode += code.slice(pointer, (regexp.lastIndex - matchLength));
+          obscureCode = obscureCode.padEnd(
+            obscureCode.length + matchLength, 'x');
+          pointer = regexp.lastIndex;
+        }
       }
+      obscureCode += code.slice(pointer, code.length);
       return obscureCode;
     };
 
@@ -88,7 +92,7 @@ tie.factory('PythonPrereqCheckService', [
      *    WRONG_LANGUAGE_ERRORS.
      */
     var detectAndGetWrongLanguageType = function(code) {
-      var rawCodeArray = obscureStringLines(code).split('\n');
+      var rawCodeArray = obscureStringCharacters(code).split('\n');
 
       for (var i = 0; i < WRONG_LANGUAGE_ERRORS.python.length; i++) {
         var error = WRONG_LANGUAGE_ERRORS.python[i];
@@ -336,6 +340,7 @@ tie.factory('PythonPrereqCheckService', [
       extractTopLevelFunctionLines: extractTopLevelFunctionLines,
       getImportedLibraries: getImportedLibraries,
       getNonStringLines: getNonStringLines,
+      obscureStringCharacters: obscureStringCharacters,
       getUnsupportedImports: getUnsupportedImports,
       hasInvalidAuxiliaryClassCalls: hasInvalidAuxiliaryClassCalls,
       hasInvalidStudentClassCalls: hasInvalidStudentClassCalls,

--- a/client/question/services/code_evaluators/PythonPrereqCheckService.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckService.js
@@ -97,19 +97,18 @@ tie.factory('PythonPrereqCheckService', [
         // Lookup character location of error
         var firstErrorColumnNumber = obscuredCode.search(regexp);
         if (firstErrorColumnNumber !== -1) {
-          var firstErrorLineNumber = null;
+          var firstErrorLineNumber = 0;
 
           // After regex matches an error, loop through codelines
           for (var l = 0; firstErrorColumnNumber >= 0; l++) {
             // Subtract l.length from firstErrorCharIndex.
             // At/below 0: index === linenumber. Subtract +1 for newline char.
             firstErrorColumnNumber -= (rawCodeArray[l].length + 1);
+            firstErrorLineNumber++;
           }
 
-          if (l !== undefined) {
-            firstErrorLineNumber = l;
-            firstErrorColumnNumber += rawCodeArray[l - 1].length;
-          }
+          firstErrorColumnNumber += rawCodeArray[
+            firstErrorLineNumber - 1].length;
 
           return PrereqCheckErrorObjectFactory.create(
             error.errorName, firstErrorLineNumber, firstErrorColumnNumber);

--- a/client/question/services/code_evaluators/PythonPrereqCheckService.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckService.js
@@ -64,8 +64,8 @@ tie.factory('PythonPrereqCheckService', [
      * @return {string} code where all 'foo' & "bar" converted to xxxxx & xxxxx
      */
     var getObscuredCode = function(code) {
-      var escapeRegexp = new RegExp(/\\[\w,',",\\]/, 'g');
-      var regexp = new RegExp(/'([^']*)'|"([^"]*)"/, 'g');
+      var escapeRegexp = new RegExp(/\\[\w'"\\]/, 'g');
+      var stringRegexp = new RegExp(/'([^']*)'|"([^"]*)"/, 'g');
 
       /**
        * Replace method callback converts regex matches with 'x'
@@ -74,7 +74,7 @@ tie.factory('PythonPrereqCheckService', [
         return ''.padStart(match.length, 'x');
       };
 
-      return code.replace(escapeRegexp, obscure).replace(regexp, obscure);
+      return code.replace(escapeRegexp, obscure).replace(stringRegexp, obscure);
     };
 
     /**
@@ -95,19 +95,20 @@ tie.factory('PythonPrereqCheckService', [
         var regexp = new RegExp(error.regExString);
 
         // Lookup character location of error
-        var firstErrorColumnNumber = obscuredCode.search(regexp);
-        if (firstErrorColumnNumber !== -1) {
+        var firstErrorCharNumber = obscuredCode.search(regexp);
+        if (firstErrorCharNumber !== -1) {
           var firstErrorLineNumber = 0;
 
           // After regex matches an error, loop through codelines
-          for (var l = 0; firstErrorColumnNumber >= 0; l++) {
-            // Subtract l.length from firstErrorCharIndex.
-            // At/below 0: index === linenumber. Subtract +1 for newline char.
-            firstErrorColumnNumber -= (rawCodeArray[l].length + 1);
+          for (var l = 0; firstErrorCharNumber >= 0; l++) {
+            // Subtract line length from corresponding firstErrorCharNumber.
+            // When below 0: index === linenumber. Subtract +1 for newline char.
+            firstErrorCharNumber -= (rawCodeArray[l].length + 1);
             firstErrorLineNumber++;
           }
 
-          firstErrorColumnNumber += rawCodeArray[
+          // Add line length to the >0 firstErrorColumnNumber
+          var firstErrorColumnNumber = firstErrorCharNumber + rawCodeArray[
             firstErrorLineNumber - 1].length;
 
           return PrereqCheckErrorObjectFactory.create(

--- a/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -255,7 +255,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual(
+      expect(prereqFailureType.getErrorName()).toEqual(
         "incrementOp");
     });
 
@@ -268,7 +268,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual(
+      expect(prereqFailureType.getErrorName()).toEqual(
         "decrementOp");
     });
 
@@ -281,7 +281,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('javaComment');
+      expect(prereqFailureType.getErrorName()).toEqual('javaComment');
     });
 
     it('correctly returns "javaComment" when ' +
@@ -295,7 +295,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('javaComment');
+      expect(prereqFailureType.getErrorName()).toEqual('javaComment');
     });
 
     it('correctly returns "switch" when the ' +
@@ -310,7 +310,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('switch');
+      expect(prereqFailureType.getErrorName()).toEqual('switch');
     });
 
     it('correctly returns "elseIf" when the ' +
@@ -325,7 +325,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('elseIf');
+      expect(prereqFailureType.getErrorName()).toEqual('elseIf');
     });
 
     it('correctly returns "booleans" when the ' +
@@ -337,8 +337,8 @@ describe('PythonPrereqCheckService', function() {
         ''
       ].join('\n');
       expect(
-        PythonPrereqCheckService.detectAndGetWrongLanguageType(code).errorName
-      ).toEqual('booleans');
+        PythonPrereqCheckService.detectAndGetWrongLanguageType(code)
+        .getErrorName()).toEqual('booleans');
 
       code = [
         'def myFunction(arg):',
@@ -347,8 +347,8 @@ describe('PythonPrereqCheckService', function() {
         ''
       ].join('\n');
       expect(
-        PythonPrereqCheckService.detectAndGetWrongLanguageType(code).errorName
-      ).toEqual('booleans');
+        PythonPrereqCheckService.detectAndGetWrongLanguageType(code)
+        .getErrorName()).toEqual('booleans');
 
       code = [
         'def myFunction(arg):',
@@ -357,8 +357,8 @@ describe('PythonPrereqCheckService', function() {
         ''
       ].join('\n');
       expect(
-        PythonPrereqCheckService.detectAndGetWrongLanguageType(code).errorName
-      ).toEqual('booleans');
+        PythonPrereqCheckService.detectAndGetWrongLanguageType(code)
+        .getErrorName()).toEqual('booleans');
 
       code = [
         'def myFunction(arg):',
@@ -367,8 +367,8 @@ describe('PythonPrereqCheckService', function() {
         ''
       ].join('\n');
       expect(
-        PythonPrereqCheckService.detectAndGetWrongLanguageType(code).errorName
-      ).toEqual('booleans');
+        PythonPrereqCheckService.detectAndGetWrongLanguageType(code)
+        .getErrorName()).toEqual('booleans');
 
       code = [
         'def myFunction(arg):',
@@ -391,7 +391,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('push');
+      expect(prereqFailureType.getErrorName()).toEqual('push');
     });
 
     it('correctly returns "catch" when the ' +
@@ -406,7 +406,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('catch');
+      expect(prereqFailureType.getErrorName()).toEqual('catch');
     });
 
     it('correctly returns "doWhile" when the ' +
@@ -420,7 +420,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('doWhile');
+      expect(prereqFailureType.getErrorName()).toEqual('doWhile');
     });
 
     it('correctly returns "cImport" when the ' +
@@ -434,7 +434,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('cImport');
+      expect(prereqFailureType.getErrorName()).toEqual('cImport');
     });
 
     it('correctly returns "andOp" when the ' +
@@ -448,7 +448,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('andOp');
+      expect(prereqFailureType.getErrorName()).toEqual('andOp');
     });
 
     it('correctly returns "orOp" when the ' +
@@ -462,7 +462,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('orOp');
+      expect(prereqFailureType.getErrorName()).toEqual('orOp');
     });
 
     it('correctly returns "notOp" when the ' +
@@ -475,7 +475,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType.errorName).toEqual('notOp');
+      expect(prereqFailureType.getErrorName()).toEqual('notOp');
     });
 
     it('ignores lines with strings for non-multiline checks', function() {

--- a/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -493,7 +493,33 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual(null);
+      expect(prereqFailureType).toEqual(
+        jasmine.objectContaining({
+          _errorName: 'notOp',
+          _errorLineNumber: 2,
+          _errorType: 'wrongLang'
+        }));
+    });
+  });
+
+  describe('obscureStringCharacters', function() {
+    it('obscure strings to test while preserving character length', function() {
+
+      var code = [
+        'def myFunction(arg):',
+        '    if "!arg":',
+        '        return arg',
+        '',
+        '    if (!arg + "abc"):',
+        '        return arg',
+        ''
+      ].join('\n');
+      var obscureCode =
+        PythonPrereqCheckService.obscureStringCharacters(code);
+
+      expect(code.length).toEqual(obscureCode.length);
+      expect(obscureCode).toContain('if xxxxxx');
+      expect(obscureCode).toContain('if (!arg + xxxxx):');
     });
   });
 

--- a/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -494,11 +494,13 @@ describe('PythonPrereqCheckService', function() {
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
 
+      // No Magic Numbers.
+      var errorLine = 5;
+      var errorColumn = 7;
+
       expect(prereqFailureType.getErrorName()).toEqual('notOp');
-      expect(prereqFailureType.getErrorLineNumber()).toEqual(
-        prereqFailureType._errorLineNumber);
-      expect(prereqFailureType.getErrorColumnNumber()).toEqual(
-        prereqFailureType._errorColumnNumber);
+      expect(prereqFailureType.getErrorLineNumber()).toEqual(errorLine);
+      expect(prereqFailureType.getErrorColumnNumber()).toEqual(errorColumn);
       expect(prereqFailureType._errorType).toEqual('wrongLang');
 
     });
@@ -506,12 +508,19 @@ describe('PythonPrereqCheckService', function() {
 
   describe('obscureStringCharacters', function() {
     it('obscures escaped characters', function() {
+      const BACKSLASH = '\\';
+      const SINGLE_QUOTE = '\'';
+      const DOUBLE_QUOTE = "\"";
 
-      var backslash = "\\\\";
-      var backslashedBackslash = "\\\\\\\\";
-      var singlequotes = '\\\'\\\'\\\'';
-      var doublequotes = "\\\"\\\"\\\"";
-      var mixed = '  \\\' hello world\\\'s \\\'  ';
+      // Looking to capture what a user might input, so \" would have to \\" to
+      // Appropriately replicate the user input.
+      var backslash = '\\' + BACKSLASH;
+      var backslashedBackslash = '\\' + BACKSLASH + '\\' + BACKSLASH;
+      var singlequotes = '\\' + SINGLE_QUOTE + '\\' + SINGLE_QUOTE;
+      var doublequotes = '\\' + DOUBLE_QUOTE + '\\' + DOUBLE_QUOTE;
+      var mixed = (
+        '  \\' + SINGLE_QUOTE + ' hello world\\' + SINGLE_QUOTE + 's \\' +
+        SINGLE_QUOTE + '  ');
       var newLine = '\\n';
       var tabChar = '\\t';
 
@@ -520,9 +529,9 @@ describe('PythonPrereqCheckService', function() {
       expect(PythonPrereqCheckService.getObscuredCode(backslashedBackslash))
         .toEqual('xxxx');
       expect(PythonPrereqCheckService.getObscuredCode(singlequotes))
-        .toEqual('xxxxxx');
+        .toEqual('xxxx');
       expect(PythonPrereqCheckService.getObscuredCode(doublequotes))
-        .toEqual('xxxxxx');
+        .toEqual('xxxx');
       expect(PythonPrereqCheckService.getObscuredCode(mixed))
         .toEqual('  xx hello worldxxs xx  ');
       expect(PythonPrereqCheckService.getObscuredCode(newLine))
@@ -540,7 +549,7 @@ describe('PythonPrereqCheckService', function() {
       expect(obscuredVarLine.length).toEqual(varLine.length);
     });
 
-    it('obscure strings to test while preserving character length', function() {
+    it('obscures strings to test while preserving line length', function() {
 
       var code = [
         'def myFunction(arg):',
@@ -555,8 +564,14 @@ describe('PythonPrereqCheckService', function() {
         PythonPrereqCheckService.getObscuredCode(code);
 
       expect(code.length).toEqual(obscureCode.length);
-      expect(obscureCode).toContain('if xxxxxx');
-      expect(obscureCode).toContain('if (!arg + xxxxx):');
+      expect(obscureCode).toEqual([
+        'def myFunction(arg):',
+        '    if xxxxxx:',
+        '        return arg',
+        '',
+        '    if (!arg + xxxxx):',
+        '        return arg',
+        ''].join('\n'));
     });
   });
 

--- a/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -505,7 +505,7 @@ describe('PythonPrereqCheckService', function() {
   });
 
   describe('obscureStringCharacters', function() {
-    it('obscure escaped characters', function() {
+    it('obscures escaped characters', function() {
 
       var backslash = "\\\\";
       var backslashedBackslash = "\\\\\\\\";
@@ -531,7 +531,7 @@ describe('PythonPrereqCheckService', function() {
         .toEqual('xx');
     });
 
-    it('obscure escaped characters, preserve character length', function() {
+    it('obscures escaped characters, preserving character length', function() {
 
       var varLine = 'test_var = \\\'1\\\' + \\\'1\\\'';
       var obscuredVarLine = PythonPrereqCheckService.getObscuredCode(varLine);

--- a/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -255,7 +255,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual(
+      expect(prereqFailureType.errorName).toEqual(
         "incrementOp");
     });
 
@@ -268,7 +268,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual(
+      expect(prereqFailureType.errorName).toEqual(
         "decrementOp");
     });
 
@@ -281,7 +281,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('javaComment');
+      expect(prereqFailureType.errorName).toEqual('javaComment');
     });
 
     it('correctly returns "javaComment" when ' +
@@ -295,7 +295,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('javaComment');
+      expect(prereqFailureType.errorName).toEqual('javaComment');
     });
 
     it('correctly returns "switch" when the ' +
@@ -310,7 +310,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('switch');
+      expect(prereqFailureType.errorName).toEqual('switch');
     });
 
     it('correctly returns "elseIf" when the ' +
@@ -325,7 +325,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('elseIf');
+      expect(prereqFailureType.errorName).toEqual('elseIf');
     });
 
     it('correctly returns "booleans" when the ' +
@@ -337,7 +337,7 @@ describe('PythonPrereqCheckService', function() {
         ''
       ].join('\n');
       expect(
-        PythonPrereqCheckService.detectAndGetWrongLanguageType(code)
+        PythonPrereqCheckService.detectAndGetWrongLanguageType(code).errorName
       ).toEqual('booleans');
 
       code = [
@@ -347,7 +347,7 @@ describe('PythonPrereqCheckService', function() {
         ''
       ].join('\n');
       expect(
-        PythonPrereqCheckService.detectAndGetWrongLanguageType(code)
+        PythonPrereqCheckService.detectAndGetWrongLanguageType(code).errorName
       ).toEqual('booleans');
 
       code = [
@@ -357,7 +357,7 @@ describe('PythonPrereqCheckService', function() {
         ''
       ].join('\n');
       expect(
-        PythonPrereqCheckService.detectAndGetWrongLanguageType(code)
+        PythonPrereqCheckService.detectAndGetWrongLanguageType(code).errorName
       ).toEqual('booleans');
 
       code = [
@@ -367,7 +367,7 @@ describe('PythonPrereqCheckService', function() {
         ''
       ].join('\n');
       expect(
-        PythonPrereqCheckService.detectAndGetWrongLanguageType(code)
+        PythonPrereqCheckService.detectAndGetWrongLanguageType(code).errorName
       ).toEqual('booleans');
 
       code = [
@@ -391,7 +391,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('push');
+      expect(prereqFailureType.errorName).toEqual('push');
     });
 
     it('correctly returns "catch" when the ' +
@@ -406,7 +406,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('catch');
+      expect(prereqFailureType.errorName).toEqual('catch');
     });
 
     it('correctly returns "doWhile" when the ' +
@@ -420,7 +420,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('doWhile');
+      expect(prereqFailureType.errorName).toEqual('doWhile');
     });
 
     it('correctly returns "cImport" when the ' +
@@ -434,7 +434,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('cImport');
+      expect(prereqFailureType.errorName).toEqual('cImport');
     });
 
     it('correctly returns "andOp" when the ' +
@@ -448,7 +448,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('andOp');
+      expect(prereqFailureType.errorName).toEqual('andOp');
     });
 
     it('correctly returns "orOp" when the ' +
@@ -462,7 +462,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('orOp');
+      expect(prereqFailureType.errorName).toEqual('orOp');
     });
 
     it('correctly returns "notOp" when the ' +
@@ -475,7 +475,7 @@ describe('PythonPrereqCheckService', function() {
       ].join('\n');
       var prereqFailureType =
         PythonPrereqCheckService.detectAndGetWrongLanguageType(code);
-      expect(prereqFailureType).toEqual('notOp');
+      expect(prereqFailureType.errorName).toEqual('notOp');
     });
 
     it('ignores lines with strings for non-multiline checks', function() {

--- a/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
+++ b/client/question/services/code_evaluators/PythonPrereqCheckServiceSpec.js
@@ -503,6 +503,35 @@ describe('PythonPrereqCheckService', function() {
   });
 
   describe('obscureStringCharacters', function() {
+    it('obscure escaped characters', function() {
+
+      var backslash = "\\\\";
+      var backslashedBackslash = "\\\\\\\\";
+      var singlequotes = '\\\'\\\'\\\'';
+      var doublequotes = "\\\"\\\"\\\"";
+      var mixed = '\\\' hello world\\\'s \\\'';
+
+      expect(PythonPrereqCheckService.getObscuredCode(backslash))
+        .toEqual('xx');
+      expect(PythonPrereqCheckService.getObscuredCode(backslashedBackslash))
+        .toEqual('xxxx');
+      expect(PythonPrereqCheckService.getObscuredCode(singlequotes))
+        .toEqual('xxxxxx');
+      expect(PythonPrereqCheckService.getObscuredCode(doublequotes))
+        .toEqual('xxxxxx');
+      expect(PythonPrereqCheckService.getObscuredCode(mixed))
+        .toEqual('xx hello worldxxs xx');
+    });
+
+    it('obscure escaped characters, preserve character length', function() {
+
+      var varLine = 'test_var = \\\'1\\\' + \\\'1\\\'';
+      var obscuredVarLine = PythonPrereqCheckService.getObscuredCode(varLine);
+
+      expect(obscuredVarLine).toEqual("test_var = xx1xx + xx1xx");
+      expect(obscuredVarLine.length).toEqual(varLine.length);
+    });
+
     it('obscure strings to test while preserving character length', function() {
 
       var code = [
@@ -515,7 +544,7 @@ describe('PythonPrereqCheckService', function() {
         ''
       ].join('\n');
       var obscureCode =
-        PythonPrereqCheckService.obscureStringCharacters(code);
+        PythonPrereqCheckService.getObscuredCode(code);
 
       expect(code.length).toEqual(obscureCode.length);
       expect(obscureCode).toContain('if xxxxxx');


### PR DESCRIPTION
Expands the PrereqCheck to find the error line numbers, and pass it to the feedback object. To eventually highlight the line, and append to the feedback bubble.

This is PR 1 of 2, loop through the student code, find the error and pass it to the PrereqCheckFailureObjectFactory.