### PR TITLE
Adjust button width for compatibility with Firefox

### DIFF
--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -158,7 +158,7 @@ tie.directive('learnerView', [function() {
           margin-right: 10px;
           outline: none;
           padding: 1px 6px;
-          width: 104px;
+          width: 120px;
         }
         .tie-button:hover {
           border: 1px solid #e4e4e4;


### PR DESCRIPTION
Button width appears to be too narrow for default Firefox settings on Linux.