### PR TITLE
Update Analytics to capture clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-113374155-1"></script>
+  <!-- Google Analytics -->
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-113374155-1');
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-113374155-1', 'auto');
+    ga('send', 'pageview');
+    function handleOutboundLinkClicks(label) {
+      ga('send', 'event', {
+        eventCategory: 'Outbound Link',
+        eventAction: 'click',
+        eventLabel: label,
+        transport: 'beacon'
+      });
+    }
   </script>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -88,25 +97,25 @@
       </video>
       <h2>How to get started</h2>
       <ol>
-        <li><a href="https://github.com/google/tie/archive/v0.1.1-beta.zip">Download the zip file</a> <sup>*</sup></li>
+        <li><a onclick="handleOutboundLinkClicks('app-download')" href="https://github.com/google/tie/archive/v0.1.1-beta.zip">Download the zip file</a> <sup>*</sup></li>
         <li>Unzip the zip file</li>
         <li>Open the file client/question/question.html in a web browser</li>
         <li>Use the coding window on the right to code a solution and click "I think I'm done" if you think you have answer (repeat until you solve the question)</li>
       </ol>
       <p>To stop the TIE application, simply close the browser window. To remove TIE from your computer, delete the downloaded files from steps 1 and 2.</p>
-      <p class="small"><sup>*</sup> By downloading and using TIE, you agree to the terms contained in the <a href="https://github.com/google/tie/blob/master/LICENSE">TIE LICENSE file</a>.</p>
+      <p class="small"><sup>*</sup> By downloading and using TIE, you agree to the terms contained in the <a onclick="handleOutboundLinkClicks('tie-license-file')" href="https://github.com/google/tie/blob/master/LICENSE">TIE LICENSE file</a>.</p>
 
       <div class="feedback">
         <img src="./assets/feedback_grey600_48dp.png" alt="Feedback icon" width="48">
         <h3>Help us improve</h3>
-        <p>The TIE team values your feedback! Let us know what you think using our <a href="https://goo.gl/CcfCq4">feedback form</a>. We hope to hear from you!</p>
+        <p>The TIE team values your feedback! Let us know what you think using our <a onclick="handleOutboundLinkClicks('feedback-form')" href="https://goo.gl/CcfCq4">feedback form</a>. We hope to hear from you!</p>
       </div>
 
       <div class="notes">
         <p><strong>Notes</strong>:</p>
         <ul>
           <li>The project is currently in early Beta. This means that content and features are limited. We plan to add more content and features as we develop towards version 1.</li>
-          <li>For more information about TIE, see our <a href="https://github.com/google/tie/">project page</a>.</li>
+          <li>For more information about TIE, see our <a onclick="handleOutboundLinkClicks('project-page')" href="https://github.com/google/tie/">project page</a>.</li>
         </ul>
       </div>
   </div>


### PR DESCRIPTION
Since links are technically external to the page, they are not captured. This allows us to know whether users actually clicked the download link, whether they visited our page, whether they opened the license file, or whether they clicked the feedback form link.