### PR TITLE
Introduce a new CurrentQuestionService for storing question context in the learner view.

### DIFF
--- a/assets/tests/QuestionSchemaValidationServiceSpec.js
+++ b/assets/tests/QuestionSchemaValidationServiceSpec.js
@@ -32,11 +32,12 @@ describe('QuestionSchemaValidationService', function() {
     // Used for testing the validator. Values will be inserted during the tests
     // so that we don't have to redefine the dict every time.
     QuestionDataService = $injector.get('QuestionDataService');
-    QuestionSchemaValidationService =
-        $injector.get('QuestionSchemaValidationService');
+    QuestionObjectFactory = $injector.get('QuestionObjectFactory');
+    QuestionSchemaValidationService = $injector.get(
+      'QuestionSchemaValidationService');
 
     questions = QUESTION_IDS.map(function(questionId) {
-      return QuestionDataService.getQuestion(questionId);
+      return QuestionObjectFactory.create(globalData.questions[questionId]);
     });
   }));
 

--- a/assets/tests/TaskSchemaValidationServiceSpec.js
+++ b/assets/tests/TaskSchemaValidationServiceSpec.js
@@ -32,10 +32,11 @@ describe('TaskSchemaValidationService', function() {
     // Used for testing the validator. Values will be inserted during the tests
     // so that we don't have to redefine the dict every time.
     QuestionDataService = $injector.get('QuestionDataService');
+    QuestionObjectFactory = $injector.get('QuestionObjectFactory');
     TaskSchemaValidationService = $injector.get('TaskSchemaValidationService');
 
     questions = QUESTION_IDS.map(function(questionId) {
-      return QuestionDataService.getQuestion(questionId);
+      return QuestionObjectFactory.create(globalData.questions[questionId]);
     });
   }));
 

--- a/client/data/data.js
+++ b/client/data/data.js
@@ -44,3 +44,44 @@ tieData.constant('CLASS_NAME_AUXILIARY_CODE', 'AuxiliaryCode');
  * @constant
  */
 tieData.constant('CLASS_NAME_SYSTEM_CODE', 'System');
+
+/**
+ * FeedbackParagraph type that will be rendered to look like a normal text
+ * paragraph.
+ *
+ * @type {string}
+ * @constant
+ */
+tieData.constant('PARAGRAPH_TYPE_TEXT', 'text');
+
+/**
+ * FeedbackParagraph type that will render text to look like code.
+ *
+ * @type {string}
+ * @constant
+ */
+tieData.constant('PARAGRAPH_TYPE_CODE', 'code');
+
+/**
+ * FeedbackParagraph type that will render text to bring attention to an error.
+ *
+ * @type {string}
+ * @constant
+ */
+tieData.constant('PARAGRAPH_TYPE_ERROR', 'error');
+
+/**
+ * FeedbackParagraph type for displaying user code output.
+ *
+ * @type {string}
+ * @constant
+ */
+tieData.constant('PARAGRAPH_TYPE_OUTPUT', 'output');
+
+/**
+ * FeedbackParagraph type for displaying an image.
+ *
+ * @type {string}
+ * @constant
+ */
+tieData.constant('PARAGRAPH_TYPE_IMAGE', 'image');

--- a/client/data/domain/TaskObjectFactory.js
+++ b/client/data/domain/TaskObjectFactory.js
@@ -20,11 +20,11 @@
 tieData.factory('TaskObjectFactory', [
   'TipObjectFactory', 'TestSuiteObjectFactory', 'BuggyOutputTestObjectFactory',
   'SuiteLevelTestObjectFactory', 'PerformanceTestObjectFactory',
-  'CLASS_NAME_AUXILIARY_CODE', 'CLASS_NAME_SYSTEM_CODE',
+  'CLASS_NAME_AUXILIARY_CODE', 'CLASS_NAME_SYSTEM_CODE', 'PARAGRAPH_TYPE_TEXT',
   function(
       TipObjectFactory, TestSuiteObjectFactory, BuggyOutputTestObjectFactory,
       SuiteLevelTestObjectFactory, PerformanceTestObjectFactory,
-      CLASS_NAME_AUXILIARY_CODE, CLASS_NAME_SYSTEM_CODE) {
+      CLASS_NAME_AUXILIARY_CODE, CLASS_NAME_SYSTEM_CODE, PARAGRAPH_TYPE_TEXT) {
     /**
      * Task objects represent a single task for the user to complete for a
      * question. This includes all of the information, skills, and testing
@@ -187,6 +187,27 @@ tieData.factory('TaskObjectFactory', [
      */
     Task.prototype.getInstructions = function() {
       return this._instructions;
+    };
+
+    /**
+     * A getter for the text part of the instructions. Used for the summary
+     * card in the Menu page.
+     *
+     * @returns {Array}
+     */
+    Task.prototype.getTextInstructions = function() {
+      var instructions = this._instructions;
+
+      var textInstructions = '';
+      // We only need to grab the text portions of these instructions
+      // for the preview content.
+      for (var i = 0; i < instructions.length; i++) {
+        if (instructions[i].type === PARAGRAPH_TYPE_TEXT) {
+          textInstructions += instructions[i].content + ' ';
+        }
+      }
+
+      return textInstructions;
     };
 
     /**

--- a/client/data/domain/TaskObjectFactorySpec.js
+++ b/client/data/domain/TaskObjectFactorySpec.js
@@ -29,12 +29,29 @@ describe('TaskObjectFactory', function() {
       title: 'title',
       starterCode: 'starterCode',
       tasks: [{
+        instructions: [{
+          content: 'For this question, you will implement isBalanced().',
+          type: 'text'
+        }, {
+          content: 'Input: "(())"\nOutput: True',
+          type: 'code'
+        }],
         outputFunctionName: 'AuxiliaryCode.lettersOnly',
         testSuites: [],
         buggyOutputTests: [],
         suiteLevelTests: [],
         performanceTests: []
       }, {
+        instructions: [{
+          content: 'some code',
+          type: 'code'
+        }, {
+          content: 'abc',
+          type: 'text'
+        }, {
+          content: 'def',
+          type: 'text'
+        }],
         outputFunctionName: 'System.extendString',
         testSuites: [],
         buggyOutputTests: [],
@@ -52,5 +69,14 @@ describe('TaskObjectFactory', function() {
         expect(question.getTasks()[1].getOutputFunctionNameWithoutClass())
           .toEqual('extendString');
       });
+  });
+
+  describe('getTextInstructions', function() {
+    it('should get the text instructions for a task', function() {
+      expect(question.getTasks()[0].getTextInstructions())
+        .toEqual('For this question, you will implement isBalanced(). ');
+      expect(question.getTasks()[1].getTextInstructions())
+        .toEqual('abc def ');
+    });
   });
 });

--- a/client/data/services/QuestionDataServiceSpec.js
+++ b/client/data/services/QuestionDataServiceSpec.js
@@ -18,55 +18,36 @@
 
 describe('QuestionDataService', function() {
   var QuestionDataService;
+  var QuestionObjectFactory;
+  var QuestionObject;
 
   beforeEach(module('tie'));
   beforeEach(module('tieData'));
   beforeEach(inject(function($injector) {
     QuestionDataService = $injector.get('QuestionDataService');
+    QuestionObjectFactory = $injector.get('QuestionObjectFactory');
+    QuestionObject = QuestionObjectFactory.create({
+      title: "title",
+      starterCode: "starterCode",
+      auxiliaryCode: "AUXILIARY_CODE",
+      tasks: []
+    });
   }));
 
-  describe('getQuestion', function() {
+  describe('fetchQuestionAsync', function() {
+    it('should correctly get the question data', function(done) {
+      QuestionDataService.fetchQuestionAsync('reverseWords').then(
+        function(result) {
+          expect(result).toEqual(QuestionObject);
+          done();
+        }
+      );
+    });
+
     it('should throw an error if the question id does not exist', function() {
       expect(function() {
-        QuestionDataService.getQuestion('');
+        QuestionDataService.fetchQuestionAsync('');
       }).toThrowError('There is no question with ID: ');
-    });
-  });
-
-  describe('getQuestionTitle', function() {
-    it('should get the title of a question', function() {
-      var title = globalData.questions.isPalindrome.title;
-      expect(QuestionDataService.getQuestionTitle('isPalindrome'))
-        .toEqual(title);
-    });
-
-    it('should throw an error if the question does not exist', function() {
-      expect(function() {
-        QuestionDataService.getQuestionTitle('lemon');
-      }).toThrowError('There is no question with ID: lemon');
-    });
-  });
-
-  describe('getQuestionVersion', function() {
-    it('should return 1 exclusively, for now', function() {
-      expect(QuestionDataService.getQuestionVersion()).toEqual(1);
-    });
-  });
-
-  describe('getQuestionPreviewInstructions', function() {
-    it('should get the title of a question', function() {
-      expect(QuestionDataService
-        .getQuestionPreviewInstructions('checkBalancedParentheses'))
-        .toEqual('For this question, you will implement the isBalanced ' +
-                 'function. It takes a string of only parentheses as input ' +
-                 'and returns True if for every open parentheses there is a ' +
-                 'matching closing parentheses, and False otherwise. ');
-    });
-
-    it('should throw an error if the question does not exist', function() {
-      expect(function() {
-        QuestionDataService.getQuestionPreviewInstructions('grape');
-      }).toThrowError('There is no question with ID: grape');
     });
   });
 });
@@ -89,8 +70,7 @@ describe('QuestionDataServiceServerVersion', function() {
   beforeEach(inject(function($injector) {
     $httpBackend = $injector.get('$httpBackend');
     QuestionDataService = $injector.get('QuestionDataService');
-    QuestionObjectFactory = $injector.get(
-      'QuestionObjectFactory');
+    QuestionObjectFactory = $injector.get('QuestionObjectFactory');
     QuestionObject = QuestionObjectFactory.create({
       title: "title",
       starterCode: "starterCode",
@@ -99,7 +79,7 @@ describe('QuestionDataServiceServerVersion', function() {
     });
   }));
 
-  describe('getQuestionsAsync', function() {
+  describe('fetchQuestionAsync', function() {
     it('should correctly get the question data', function(done) {
       $httpBackend.expect('POST', '/ajax/get_question_data').respond(
         serverSuccessCode,
@@ -113,7 +93,7 @@ describe('QuestionDataServiceServerVersion', function() {
           }
         }
       );
-      QuestionDataService.getQuestionAsync('reverseWords').then(
+      QuestionDataService.fetchQuestionAsync('reverseWords').then(
         function(result) {
           expect(result).toEqual(QuestionObject);
           done();
@@ -126,7 +106,7 @@ describe('QuestionDataServiceServerVersion', function() {
       $httpBackend.expect('POST', '/ajax/get_question_data').respond(
         serverErrorCode, {}
       );
-      QuestionDataService.getQuestionAsync('reverseWords').then(
+      QuestionDataService.fetchQuestionAsync('reverseWords').then(
         function() {
           // Nothing happens because it errors out.
         }, function(error) {

--- a/client/menu/components/MenuQuestionCardDirective.js
+++ b/client/menu/components/MenuQuestionCardDirective.js
@@ -69,6 +69,8 @@ tieMenu.directive('menuQuestionCard', [function() {
     `,
     controller: ['$scope', 'QuestionDataService',
       function($scope, QuestionDataService) {
+        var MAX_DESCRIPTION_LENGTH = 280;
+
         var questionPromise = QuestionDataService.fetchQuestionAsync(
           $scope.questionId);
 
@@ -76,7 +78,13 @@ tieMenu.directive('menuQuestionCard', [function() {
           $scope.title = question.getTitle();
 
           var firstTask = question.getTasks()[0];
-          $scope.textInstructions = firstTask.getTextInstructions();
+          var fullInstructions = firstTask.getTextInstructions();
+          if (fullInstructions.length > MAX_DESCRIPTION_LENGTH) {
+            $scope.textInstructions = (
+              fullInstructions.substring(0, MAX_DESCRIPTION_LENGTH) + '...');
+          } else {
+            $scope.textInstructions = fullInstructions;
+          }
         });
       }
     ]

--- a/client/menu/components/MenuQuestionCardDirective.js
+++ b/client/menu/components/MenuQuestionCardDirective.js
@@ -69,9 +69,15 @@ tieMenu.directive('menuQuestionCard', [function() {
     `,
     controller: ['$scope', 'QuestionDataService',
       function($scope, QuestionDataService) {
-        $scope.title = QuestionDataService.getQuestionTitle($scope.questionId);
-        $scope.textInstructions =
-          QuestionDataService.getQuestionPreviewInstructions($scope.questionId);
+        var questionPromise = QuestionDataService.fetchQuestionAsync(
+          $scope.questionId);
+
+        questionPromise.then(function(question) {
+          $scope.title = question.getTitle();
+
+          var firstTask = question.getTasks()[0];
+          $scope.textInstructions = firstTask.getTextInstructions();
+        });
       }
     ]
   };

--- a/client/menu/menu.html
+++ b/client/menu/menu.html
@@ -7,6 +7,9 @@
     <link rel="stylesheet" href="../../assets/base.css">
     <script src="../../third_party/angular-1.6.1/angular.min.js"></script>
 
+    <script src="../config/config.js"></script>
+    <script src="../config/deploymentSpecificConfig.js"></script>
+
     <script src="../data/data.js"></script>
     <script src="../data/domain/BuggyOutputTestObjectFactory.js"></script>
     <script src="../data/domain/PerformanceTestObjectFactory.js"></script>

--- a/client/menu/menu.js
+++ b/client/menu/menu.js
@@ -16,4 +16,4 @@
  * @fileoverview Adds an importable configuration file for the TIE menu page.
  */
 
-window.tieMenu = angular.module('tieMenu', ['tieData']);
+window.tieMenu = angular.module('tieMenu', ['tieConfig', 'tieData']);

--- a/client/question/components/LearnerViewDirectiveSpec.js
+++ b/client/question/components/LearnerViewDirectiveSpec.js
@@ -24,6 +24,7 @@ describe('LearnerViewDirective', function() {
   var QuestionDataService;
   var EventHandlerService;
   var FeedbackObjectFactory;
+  var QuestionObjectFactory;
   var FEEDBACK_CATEGORIES;
   var $location;
 
@@ -55,7 +56,7 @@ describe('LearnerViewDirective', function() {
   beforeEach(inject(function(
       $compile, $rootScope, $injector, _QuestionDataService_,
       _SECONDS_TO_MILLISECONDS_, _CODE_CHANGE_DEBOUNCE_SECONDS_, _$location_,
-      _EventHandlerService_, _FeedbackObjectFactory_,
+      _EventHandlerService_, _FeedbackObjectFactory_, _QuestionObjectFactory_,
       _ConversationLogDataService_) {
     $scope = $rootScope.$new();
 
@@ -74,6 +75,7 @@ describe('LearnerViewDirective', function() {
     QuestionDataService = _QuestionDataService_;
     EventHandlerService = _EventHandlerService_;
     FeedbackObjectFactory = _FeedbackObjectFactory_;
+    QuestionObjectFactory = _QuestionObjectFactory_;
     ConversationLogDataService = _ConversationLogDataService_;
 
     SECONDS_TO_MILLISECONDS = _SECONDS_TO_MILLISECONDS_;
@@ -105,7 +107,8 @@ describe('LearnerViewDirective', function() {
 
     it('should only activate autosave once', function() {
       expect($scope.codeChangeLoopPromise).toBe(null);
-      var question = QuestionDataService.getQuestion(QUESTION_ID);
+      var question = QuestionObjectFactory.create(
+        globalData.questions[QUESTION_ID]);
       var starterCode = question.getStarterCode(LANGUAGE);
       // There should be no code stored in localStorage
       // before autosave is triggered.
@@ -218,7 +221,8 @@ describe('LearnerViewDirective', function() {
       });
       spyOn(EventHandlerService, 'createCodeResetEvent');
 
-      var question = QuestionDataService.getQuestion(QUESTION_ID);
+      var question = QuestionObjectFactory.create(
+        globalData.questions[QUESTION_ID]);
       var starterCode = question.getStarterCode(LANGUAGE);
       $scope.editorContents.code = generateRandomChars(NUM_CHARS_CODE);
       expect(starterCode).not.toEqual($scope.editorContents.code);

--- a/client/question/question.html
+++ b/client/question/question.html
@@ -68,6 +68,7 @@
     <script src="services/ConversationLogDataService.js"></script>
     <script src="services/LocalStorageService.js"></script>
     <script src="services/CookieStorageService.js"></script>
+    <script src="services/CurrentQuestionService.js"></script>
     <script src="services/EventHandlerService.js"></script>
     <script src="services/FeedbackGeneratorService.js"></script>
     <script src="services/MonospaceDisplayModalService.js"></script>

--- a/client/question/question.js
+++ b/client/question/question.js
@@ -296,47 +296,6 @@ tie.constant('PREREQ_CHECK_TYPE_GLOBAL_CODE', 'globalCode');
 tie.constant('PREREQ_CHECK_TYPE_WRONG_LANG', 'wrongLang');
 
 /**
- * FeedbackParagraph type that will be rendered to look like a normal text
- * paragraph.
- *
- * @type {string}
- * @constant
- */
-tie.constant('PARAGRAPH_TYPE_TEXT', 'text');
-
-/**
- * FeedbackParagraph type that will render text to look like code.
- *
- * @type {string}
- * @constant
- */
-tie.constant('PARAGRAPH_TYPE_CODE', 'code');
-
-/**
- * FeedbackParagraph type that will render text to bring attention to an error.
- *
- * @type {string}
- * @constant
- */
-tie.constant('PARAGRAPH_TYPE_ERROR', 'error');
-
-/**
- * FeedbackParagraph type for displaying user code output.
- *
- * @type {string}
- * @constant
- */
-tie.constant('PARAGRAPH_TYPE_OUTPUT', 'output');
-
-/**
- * FeedbackParagraph type for displaying an image.
- *
- * @type {string}
- * @constant
- */
-tie.constant('PARAGRAPH_TYPE_IMAGE', 'image');
-
-/**
  * Constant for the number of times that a user can make a mistake (i.e.
  * same error, syntax error, etc.) until we prompt them to look at the
  * primer.

--- a/client/question/services/CurrentQuestionService.js
+++ b/client/question/services/CurrentQuestionService.js
@@ -1,0 +1,58 @@
+// Copyright 2017 The TIE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview A service that maintains details of the current question.
+ */
+
+tie.factory('CurrentQuestionService', [
+  '$location', 'DEFAULT_QUESTION_ID', 'SERVER_URL', 'QuestionDataService',
+  function($location, DEFAULT_QUESTION_ID, SERVER_URL, QuestionDataService) {
+    var questionId = ($location.search().qid || DEFAULT_QUESTION_ID);
+    // Currently this always returns 1, as question versioning isn't
+    // implemented yet.
+    // TODO(eyurko): Return correct question version, once implemented.
+    var questionVersion = 1;
+    var cachedQuestion = null;
+
+    return {
+      init: function(successCallback) {
+        var that = this;
+
+        var questionPromise = QuestionDataService.fetchQuestionAsync(
+          questionId);
+        questionPromise.then(function(question) {
+          if (!question) {
+            // If the question ID in the URL is invalid, revert to using the
+            // default question ID.
+            questionId = DEFAULT_QUESTION_ID;
+            that.init(successCallback);
+          } else {
+            cachedQuestion = question;
+          }
+          successCallback();
+        });
+      },
+      getCurrentQuestionId: function() {
+        return questionId;
+      },
+      getCurrentQuestionVersion: function() {
+        return questionVersion;
+      },
+      getCurrentQuestion: function() {
+        return cachedQuestion;
+      }
+    };
+  }
+]);


### PR DESCRIPTION
This PR pulls more stuff out of the LearnerViewDirective, and does some additional cleanup in the process.

Notes:
- With this refactor, QuestionDataService is now stateless (to be used for fetching data for a given question ID), and CurrentQuestionService is stateful (it maintains information regarding the question that is currently active).
- One specific thing that this PR tries to do is to remove "global" variables within the LearnerViewDirective, so that the CurrentQuestionService and other services serve as a single source of truth for these values.
- This PR also includes a fix for the menu page to prevent question summary snippets from overflowing the tiles.