### PR TITLE
Fix Issue #564

### DIFF
--- a/client/question/services/FeedbackGeneratorService.js
+++ b/client/question/services/FeedbackGeneratorService.js
@@ -595,8 +595,9 @@ tie.factory('FeedbackGeneratorService', [
         // integrate it into the existing feedback pipeline.
         if (errorString.startsWith('TimeLimitError')) {
           return _getTimeoutErrorFeedback();
-        } else if (errorString.startsWith('ExternalError: RangeError')) {
-          return _getInfiniteLoopFeedback();
+        } else if (errorString.startsWith('ExternalError: RangeError') ||
+          errorString.includes('maximum recursion depth exceeded')) {
+            return _getInfiniteLoopFeedback();
         } else {
           return _getRuntimeErrorFeedback(codeEvalResult, rawCodeLineIndexes);
         }

--- a/client/question/services/FeedbackGeneratorService.js
+++ b/client/question/services/FeedbackGeneratorService.js
@@ -597,7 +597,7 @@ tie.factory('FeedbackGeneratorService', [
           return _getTimeoutErrorFeedback();
         } else if (errorString.startsWith('ExternalError: RangeError') ||
           errorString.includes('maximum recursion depth exceeded')) {
-            return _getInfiniteLoopFeedback();
+          return _getInfiniteLoopFeedback();
         } else {
           return _getRuntimeErrorFeedback(codeEvalResult, rawCodeLineIndexes);
         }


### PR DESCRIPTION
Add an exception if the recursion depth is exceeded -- since Skulpt kinda fakes it, it can return a fancy error, whereas we just have to check the error string itself.

Sad times.