### PR TITLE
Fix #556: Fix when "View full code" link is displayed

### DIFF
--- a/client/question/components/CodeSnippetDirective.js
+++ b/client/question/components/CodeSnippetDirective.js
@@ -27,7 +27,7 @@ tie.directive('codeSnippet', [function() {
         <span class="tie-code-snippet-line">{{line}}</span>
         <br>
       </span>
-      <span ng-if="abbreviatedSnippetLines.length <= MAX_NUM_LINES_IN_ABBREVIATED_SNIPPET">
+      <span ng-if="abbreviatedSnippetLines.length > MAX_NUM_LINES_IN_ABBREVIATED_SNIPPET">
         <a href ng-click="openCodeModal()" ng-if="!isModalOpen()">View full code</a>
         <span ng-if="isModalOpen()">View full code</span>
       </span>
@@ -93,6 +93,7 @@ tie.directive('codeSnippet', [function() {
             $scope.abbreviatedSnippetLines = [
               $scope.snippetLines[0],
               $scope.snippetLines[1],
+              $scope.snippetLines[2],
               '...'
             ];
           }


### PR DESCRIPTION
Note: This fixes a bug in the user submitted code speech balloons. It also fixed the issue observed in #556 ; however, if feedback speech balloon prints code snippets longer than 3 lines, it will be truncated as well. But I think that's fine because this places a limit on how much code text is placed in feedback speech balloons, and the point of the separate code windows is to offload lengthy code into a separate UI element.