### PR TITLE
Un-reverse order in vertical layout

### DIFF
--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -566,7 +566,7 @@ tie.directive('learnerView', [function() {
           }
           .tie-question-ui-inner {
             display: flex;
-            flex-direction: column-reverse;
+            flex-direction: column;
             padding-left: 0;
             padding-right: 0;
             white-space: nowrap;

--- a/tests/e2e/question.spec.js
+++ b/tests/e2e/question.spec.js
@@ -90,7 +90,7 @@ describe('Question Page', function() {
        // Coding and Question UI should be vertically aligned.
        expect(codingUiLocation.x).toEqual(questionUiLocation.x);
 
-       // Question UI should be below Coding UI.
+       // Question UI should be above Coding UI.
        expect(codingUiLocation.y).toBeGreaterThan(
          questionUiLocation.y + questionUiSize.height);
      });

--- a/tests/e2e/question.spec.js
+++ b/tests/e2e/question.spec.js
@@ -84,15 +84,15 @@ describe('Question Page', function() {
        await testUtils.setSmallScreen();
 
        let questionUiLocation = await questionPage.getQuestionUiLocation();
+       let questionUiSize = await questionPage.getQuestionUiSize();
        let codingUiLocation = await questionPage.getCodingUiLocation();
-       let codingUiSize = await questionPage.getCodingUiSize();
 
        // Coding and Question UI should be vertically aligned.
        expect(codingUiLocation.x).toEqual(questionUiLocation.x);
 
        // Question UI should be below Coding UI.
-       expect(questionUiLocation.y).toBeGreaterThan(
-         codingUiLocation.y + codingUiSize.height);
+       expect(codingUiLocation.y).toBeGreaterThan(
+         questionUiLocation.y + questionUiSize.height);
      });
 
   it('should fit the question and coding UIs in page width on large screens',


### PR DESCRIPTION
This PR changes order of the feedback and coding windows in vertical/portrait mode. This is for a few reasons: (a) currently, the pop-up/modal covers the feedback window in horizontal layout and the coding window in vertical layout--this change lets it cover the feedback window in both modes with little to no changes to the pop-up/modal (b) users might not notice the feedback window if they do not scroll down enough--whereas with the proposed layout, it's fine because we can point the users to the coding window anyway and (c) the existing behavior is counter to normal wrapping behavior.