### PR TITLE
Disable theme selector instead of hiding it

### DIFF
--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -54,11 +54,12 @@ tie.directive('learnerView', [function() {
                     content="content">
                 </monospace-display-modal>
               </div>
-              <div ng-hide="MonospaceDisplayModalService.isDisplayed()">
+              <div>
                 <select class="tie-select-menu protractor-test-theme-select"
                     ng-change="changeTheme(currentThemeName)"
                     ng-model="currentThemeName"
                     ng-options="i.themeName as i.themeName for i in themes"
+                    ng-disabled="MonospaceDisplayModalService.isDisplayed()"
                     title="Change between light and dark themes">
                 </select>
               </div>


### PR DESCRIPTION
When the selector is hidden, it affects other elements and creates jank by shifting windows a bit. Disabling the selector does not do this while still preventing the user from using the selector.